### PR TITLE
Xcode updates and changes for latest Cinder

### DIFF
--- a/samples/FtpClient/include/TcpClientConnection.h
+++ b/samples/FtpClient/include/TcpClientConnection.h
@@ -50,9 +50,9 @@ public:
 
 	void					close();
 	void					connect( const std::string& host, int16_t port );
-	void					write( const ci::Buffer& buffer );
+	void					write( const ci::BufferRef& buffer );
 
-	const ci::Buffer&		getBuffer() const;
+	const ci::BufferRef&    getBuffer() const;
 	bool					isConnected() const;
 protected:
 	TcpClientConnection( asio::io_service& io );

--- a/samples/FtpClient/include/TcpSessionEventHandler.h
+++ b/samples/FtpClient/include/TcpSessionEventHandler.h
@@ -44,18 +44,18 @@ class TcpSessionEventHandler : public TcpSessionEventHandlerInterface
 public:
 	TcpSessionEventHandler();
 	
-	const ci::Buffer&	getBuffer() const;
+	const ci::BufferRef&	getBuffer() const;
 	const std::string&	getError() const;
 	bool				isReadComplete() const;
 	bool				isWriteComplete() const;
 	
 	void				onClose();
 	void				onError( std::string err, size_t bytesTransferred );
-	void				onRead( ci::Buffer buffer );
+	void				onRead( ci::BufferRef buffer );
 	void				onReadComplete();
 	void				onWrite( size_t bytesTransferred );
 protected:
-	ci::Buffer			mBuffer;
+	ci::BufferRef		mBuffer;
 	std::string			mError;
 	bool				mReadComplete;
 	bool				mWriteComplete;

--- a/samples/FtpClient/src/FtpClientApp.cpp
+++ b/samples/FtpClient/src/FtpClientApp.cpp
@@ -139,8 +139,8 @@ void FtpClientApp::update()
 
 	if ( mConnectionControl->isConnected()	&& 
 		 mConnectionControl->getBuffer()	&& 
-		 mConnectionControl->getBuffer().getDataSize() > 0 ) {
-		const Buffer& buffer = mConnectionControl->getBuffer();
+		 mConnectionControl->getBuffer()->getSize() > 0 ) {
+		const BufferRef& buffer = mConnectionControl->getBuffer();
 
 		string s = ProtocolInterface::bufferToString( buffer );
 		

--- a/samples/FtpClient/src/FtpClientApp.cpp
+++ b/samples/FtpClient/src/FtpClientApp.cpp
@@ -102,8 +102,8 @@ void FtpClientApp::setup()
 	
 	mParams = params::InterfaceGl::create( "Params", ivec2( 200, 120 ) );
 	mParams->addParam( "Frame rate",	&mFrameRate,			"", true );
-	mParams->addParam( "Full screen",	&mFullScreen ).key( "f" );
-	mParams->addButton( "Quit",			[ & ]() { quit(); },	"key=q" );
+    mParams->addParam( "Full screen",	&mFullScreen,           "key=f" );
+    mParams->addButton( "Quit",			[ & ]() { quit(); },	"key=q" );
 	
 	mConnectionControl = TcpClientConnection::create( io_service() );
 

--- a/samples/FtpClient/src/TcpClientConnection.cpp
+++ b/samples/FtpClient/src/TcpClientConnection.cpp
@@ -75,14 +75,14 @@ void TcpClientConnection::connect( const string& host, int16_t port )
 	mClient->connect( host, port );
 }
 
-void TcpClientConnection::write( const Buffer& buffer )
+void TcpClientConnection::write( const BufferRef& buffer )
 {
 	if ( isConnected() ) {
 		mClientEventHandler.getSession()->write( buffer );
 	}
 }
 
-const Buffer& TcpClientConnection::getBuffer() const
+const BufferRef& TcpClientConnection::getBuffer() const
 {
 	return mSessionEventHandler.getBuffer();
 }

--- a/samples/FtpClient/src/TcpSessionEventHandler.cpp
+++ b/samples/FtpClient/src/TcpSessionEventHandler.cpp
@@ -45,7 +45,7 @@ TcpSessionEventHandler::TcpSessionEventHandler()
 {
 }
 
-const Buffer& TcpSessionEventHandler::getBuffer() const
+const BufferRef& TcpSessionEventHandler::getBuffer() const
 {
 	return mBuffer;
 }
@@ -75,15 +75,15 @@ void TcpSessionEventHandler::onError( string err, size_t bytesTransferred )
 	mError = err;
 }
 
-void TcpSessionEventHandler::onRead( Buffer buffer )
+void TcpSessionEventHandler::onRead( BufferRef buffer )
 {
-	size_t len = buffer.getDataSize();
+	size_t len = buffer->getSize();
 	if ( !mBuffer ) {
-		mBuffer = Buffer( len );
+        mBuffer = Buffer::create( len );
 	} else {
-		mBuffer.resize( mBuffer.getDataSize() + len );
+		mBuffer->resize( mBuffer->getSize() + len );
 	}
-	mBuffer.copyFrom( buffer.getData(), len );
+	mBuffer->copyFrom( buffer->getData(), len );
 	mError	= "";
 }
 

--- a/samples/FtpClient/xcode/FtpClient.xcodeproj/project.pbxproj
+++ b/samples/FtpClient/xcode/FtpClient.xcodeproj/project.pbxproj
@@ -16,17 +16,6 @@
 		5323E6B60EAFCA7E003A9687 /* QTKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5323E6B50EAFCA7E003A9687 /* QTKit.framework */; };
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
 		94EE751DCA5C4F7A8CD38C63 /* CinderApp.icns in Resources */ = {isa = PBXBuildFile; fileRef = B14A5DB1785B4DB99B78CED8 /* CinderApp.icns */; };
-		AE84AC6A19787C9400C32419 /* ClientInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84AC4A19787C9400C32419 /* ClientInterface.cpp */; };
-		AE84AC6B19787C9400C32419 /* DispatcherInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84AC4D19787C9400C32419 /* DispatcherInterface.cpp */; };
-		AE84AC6C19787C9400C32419 /* ServerInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84AC5019787C9400C32419 /* ServerInterface.cpp */; };
-		AE84AC6D19787C9400C32419 /* SessionInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84AC5319787C9400C32419 /* SessionInterface.cpp */; };
-		AE84AC6E19787C9400C32419 /* TcpClient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84AC5519787C9400C32419 /* TcpClient.cpp */; };
-		AE84AC6F19787C9400C32419 /* TcpServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84AC5819787C9400C32419 /* TcpServer.cpp */; };
-		AE84AC7019787C9400C32419 /* TcpSession.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84AC5B19787C9400C32419 /* TcpSession.cpp */; };
-		AE84AC7119787C9400C32419 /* UdpClient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84AC5E19787C9400C32419 /* UdpClient.cpp */; };
-		AE84AC7219787C9400C32419 /* UdpServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84AC6119787C9400C32419 /* UdpServer.cpp */; };
-		AE84AC7319787C9400C32419 /* UdpSession.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84AC6419787C9400C32419 /* UdpSession.cpp */; };
-		AE84AC7419787C9400C32419 /* WaitTimer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84AC6719787C9400C32419 /* WaitTimer.cpp */; };
 		AECD959F1990289B00FB1337 /* FtpClientApp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AECD959B1990289B00FB1337 /* FtpClientApp.cpp */; };
 		AECD95A01990289B00FB1337 /* TcpClientConnection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AECD959C1990289B00FB1337 /* TcpClientConnection.cpp */; };
 		AECD95A11990289B00FB1337 /* TcpClientEventHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AECD959D1990289B00FB1337 /* TcpClientEventHandler.cpp */; };
@@ -41,6 +30,21 @@
 		AECD95C21990290C00FB1337 /* HttpResponse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AECD95B51990290C00FB1337 /* HttpResponse.cpp */; };
 		AECD95C31990290C00FB1337 /* KeyValuePairInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AECD95B71990290C00FB1337 /* KeyValuePairInterface.cpp */; };
 		AECD95C41990290C00FB1337 /* ProtocolInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AECD95B91990290C00FB1337 /* ProtocolInterface.cpp */; };
+		F71B6A661B48D4440041EB6D /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F71B6A641B48D4350041EB6D /* CoreMedia.framework */; };
+		F71B6A671B48D4440041EB6D /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F71B6A621B48D42F0041EB6D /* AVFoundation.framework */; };
+		F71B6A681B48D4440041EB6D /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F71B6A601B48D4290041EB6D /* IOSurface.framework */; };
+		F71B6A691B48D4440041EB6D /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F71B6A5E1B48D4220041EB6D /* IOKit.framework */; };
+		F71B6A8C1B48D4770041EB6D /* ClientInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F71B6A6C1B48D4770041EB6D /* ClientInterface.cpp */; };
+		F71B6A8D1B48D4770041EB6D /* DispatcherInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F71B6A6F1B48D4770041EB6D /* DispatcherInterface.cpp */; };
+		F71B6A8E1B48D4770041EB6D /* ServerInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F71B6A721B48D4770041EB6D /* ServerInterface.cpp */; };
+		F71B6A8F1B48D4770041EB6D /* SessionInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F71B6A751B48D4770041EB6D /* SessionInterface.cpp */; };
+		F71B6A901B48D4770041EB6D /* TcpClient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F71B6A771B48D4770041EB6D /* TcpClient.cpp */; };
+		F71B6A911B48D4770041EB6D /* TcpServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F71B6A7A1B48D4770041EB6D /* TcpServer.cpp */; };
+		F71B6A921B48D4770041EB6D /* TcpSession.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F71B6A7D1B48D4770041EB6D /* TcpSession.cpp */; };
+		F71B6A931B48D4770041EB6D /* UdpClient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F71B6A801B48D4770041EB6D /* UdpClient.cpp */; };
+		F71B6A941B48D4770041EB6D /* UdpServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F71B6A831B48D4770041EB6D /* UdpServer.cpp */; };
+		F71B6A951B48D4770041EB6D /* UdpSession.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F71B6A861B48D4770041EB6D /* UdpSession.cpp */; };
+		F71B6A961B48D4770041EB6D /* WaitTimer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F71B6A891B48D4770041EB6D /* WaitTimer.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -58,39 +62,6 @@
 		5323E6B10EAFCA74003A9687 /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = /System/Library/Frameworks/CoreVideo.framework; sourceTree = "<absolute>"; };
 		5323E6B50EAFCA7E003A9687 /* QTKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QTKit.framework; path = /System/Library/Frameworks/QTKit.framework; sourceTree = "<absolute>"; };
 		8D1107320486CEB800E47090 /* FtpClient.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FtpClient.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		AE84AC4919787C9400C32419 /* ClientEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ClientEventHandlerInterface.h; path = "../../../blocks/Cinder-Asio/src/ClientEventHandlerInterface.h"; sourceTree = "<group>"; };
-		AE84AC4A19787C9400C32419 /* ClientInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ClientInterface.cpp; path = "../../../blocks/Cinder-Asio/src/ClientInterface.cpp"; sourceTree = "<group>"; };
-		AE84AC4B19787C9400C32419 /* ClientInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ClientInterface.h; path = "../../../blocks/Cinder-Asio/src/ClientInterface.h"; sourceTree = "<group>"; };
-		AE84AC4C19787C9400C32419 /* DispatcherEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DispatcherEventHandlerInterface.h; path = "../../../blocks/Cinder-Asio/src/DispatcherEventHandlerInterface.h"; sourceTree = "<group>"; };
-		AE84AC4D19787C9400C32419 /* DispatcherInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DispatcherInterface.cpp; path = "../../../blocks/Cinder-Asio/src/DispatcherInterface.cpp"; sourceTree = "<group>"; };
-		AE84AC4E19787C9400C32419 /* DispatcherInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DispatcherInterface.h; path = "../../../blocks/Cinder-Asio/src/DispatcherInterface.h"; sourceTree = "<group>"; };
-		AE84AC4F19787C9400C32419 /* ServerEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ServerEventHandlerInterface.h; path = "../../../blocks/Cinder-Asio/src/ServerEventHandlerInterface.h"; sourceTree = "<group>"; };
-		AE84AC5019787C9400C32419 /* ServerInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ServerInterface.cpp; path = "../../../blocks/Cinder-Asio/src/ServerInterface.cpp"; sourceTree = "<group>"; };
-		AE84AC5119787C9400C32419 /* ServerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ServerInterface.h; path = "../../../blocks/Cinder-Asio/src/ServerInterface.h"; sourceTree = "<group>"; };
-		AE84AC5219787C9400C32419 /* SessionEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SessionEventHandlerInterface.h; path = "../../../blocks/Cinder-Asio/src/SessionEventHandlerInterface.h"; sourceTree = "<group>"; };
-		AE84AC5319787C9400C32419 /* SessionInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SessionInterface.cpp; path = "../../../blocks/Cinder-Asio/src/SessionInterface.cpp"; sourceTree = "<group>"; };
-		AE84AC5419787C9400C32419 /* SessionInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SessionInterface.h; path = "../../../blocks/Cinder-Asio/src/SessionInterface.h"; sourceTree = "<group>"; };
-		AE84AC5519787C9400C32419 /* TcpClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TcpClient.cpp; path = "../../../blocks/Cinder-Asio/src/TcpClient.cpp"; sourceTree = "<group>"; };
-		AE84AC5619787C9400C32419 /* TcpClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpClient.h; path = "../../../blocks/Cinder-Asio/src/TcpClient.h"; sourceTree = "<group>"; };
-		AE84AC5719787C9400C32419 /* TcpClientEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpClientEventHandlerInterface.h; path = "../../../blocks/Cinder-Asio/src/TcpClientEventHandlerInterface.h"; sourceTree = "<group>"; };
-		AE84AC5819787C9400C32419 /* TcpServer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TcpServer.cpp; path = "../../../blocks/Cinder-Asio/src/TcpServer.cpp"; sourceTree = "<group>"; };
-		AE84AC5919787C9400C32419 /* TcpServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpServer.h; path = "../../../blocks/Cinder-Asio/src/TcpServer.h"; sourceTree = "<group>"; };
-		AE84AC5A19787C9400C32419 /* TcpServerEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpServerEventHandlerInterface.h; path = "../../../blocks/Cinder-Asio/src/TcpServerEventHandlerInterface.h"; sourceTree = "<group>"; };
-		AE84AC5B19787C9400C32419 /* TcpSession.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TcpSession.cpp; path = "../../../blocks/Cinder-Asio/src/TcpSession.cpp"; sourceTree = "<group>"; };
-		AE84AC5C19787C9400C32419 /* TcpSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpSession.h; path = "../../../blocks/Cinder-Asio/src/TcpSession.h"; sourceTree = "<group>"; };
-		AE84AC5D19787C9400C32419 /* TcpSessionEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpSessionEventHandlerInterface.h; path = "../../../blocks/Cinder-Asio/src/TcpSessionEventHandlerInterface.h"; sourceTree = "<group>"; };
-		AE84AC5E19787C9400C32419 /* UdpClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UdpClient.cpp; path = "../../../blocks/Cinder-Asio/src/UdpClient.cpp"; sourceTree = "<group>"; };
-		AE84AC5F19787C9400C32419 /* UdpClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpClient.h; path = "../../../blocks/Cinder-Asio/src/UdpClient.h"; sourceTree = "<group>"; };
-		AE84AC6019787C9400C32419 /* UdpClientEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpClientEventHandlerInterface.h; path = "../../../blocks/Cinder-Asio/src/UdpClientEventHandlerInterface.h"; sourceTree = "<group>"; };
-		AE84AC6119787C9400C32419 /* UdpServer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UdpServer.cpp; path = "../../../blocks/Cinder-Asio/src/UdpServer.cpp"; sourceTree = "<group>"; };
-		AE84AC6219787C9400C32419 /* UdpServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpServer.h; path = "../../../blocks/Cinder-Asio/src/UdpServer.h"; sourceTree = "<group>"; };
-		AE84AC6319787C9400C32419 /* UdpServerEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpServerEventHandlerInterface.h; path = "../../../blocks/Cinder-Asio/src/UdpServerEventHandlerInterface.h"; sourceTree = "<group>"; };
-		AE84AC6419787C9400C32419 /* UdpSession.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UdpSession.cpp; path = "../../../blocks/Cinder-Asio/src/UdpSession.cpp"; sourceTree = "<group>"; };
-		AE84AC6519787C9400C32419 /* UdpSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpSession.h; path = "../../../blocks/Cinder-Asio/src/UdpSession.h"; sourceTree = "<group>"; };
-		AE84AC6619787C9400C32419 /* UdpSessionEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpSessionEventHandlerInterface.h; path = "../../../blocks/Cinder-Asio/src/UdpSessionEventHandlerInterface.h"; sourceTree = "<group>"; };
-		AE84AC6719787C9400C32419 /* WaitTimer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = WaitTimer.cpp; path = "../../../blocks/Cinder-Asio/src/WaitTimer.cpp"; sourceTree = "<group>"; };
-		AE84AC6819787C9400C32419 /* WaitTimer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WaitTimer.h; path = "../../../blocks/Cinder-Asio/src/WaitTimer.h"; sourceTree = "<group>"; };
-		AE84AC6919787C9400C32419 /* WaitTimerEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WaitTimerEventHandlerInterface.h; path = "../../../blocks/Cinder-Asio/src/WaitTimerEventHandlerInterface.h"; sourceTree = "<group>"; };
 		AECD959B1990289B00FB1337 /* FtpClientApp.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FtpClientApp.cpp; path = ../src/FtpClientApp.cpp; sourceTree = "<group>"; };
 		AECD959C1990289B00FB1337 /* TcpClientConnection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TcpClientConnection.cpp; path = ../src/TcpClientConnection.cpp; sourceTree = "<group>"; };
 		AECD959D1990289B00FB1337 /* TcpClientEventHandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TcpClientEventHandler.cpp; path = ../src/TcpClientEventHandler.cpp; sourceTree = "<group>"; };
@@ -120,6 +91,44 @@
 		AECD95B91990290C00FB1337 /* ProtocolInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ProtocolInterface.cpp; path = ../../../src/ProtocolInterface.cpp; sourceTree = "<group>"; };
 		AECD95BA1990290C00FB1337 /* ProtocolInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ProtocolInterface.h; path = ../../../src/ProtocolInterface.h; sourceTree = "<group>"; };
 		B14A5DB1785B4DB99B78CED8 /* CinderApp.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = CinderApp.icns; path = ../resources/CinderApp.icns; sourceTree = "<group>"; };
+		F71B6A5E1B48D4220041EB6D /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
+		F71B6A601B48D4290041EB6D /* IOSurface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOSurface.framework; path = System/Library/Frameworks/IOSurface.framework; sourceTree = SDKROOT; };
+		F71B6A621B48D42F0041EB6D /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
+		F71B6A641B48D4350041EB6D /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
+		F71B6A6A1B48D4770041EB6D /* CinderAsio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CinderAsio.h; path = "../../../../Cinder-Asio/src/CinderAsio.h"; sourceTree = "<group>"; };
+		F71B6A6B1B48D4770041EB6D /* ClientEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ClientEventHandlerInterface.h; path = "../../../../Cinder-Asio/src/ClientEventHandlerInterface.h"; sourceTree = "<group>"; };
+		F71B6A6C1B48D4770041EB6D /* ClientInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ClientInterface.cpp; path = "../../../../Cinder-Asio/src/ClientInterface.cpp"; sourceTree = "<group>"; };
+		F71B6A6D1B48D4770041EB6D /* ClientInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ClientInterface.h; path = "../../../../Cinder-Asio/src/ClientInterface.h"; sourceTree = "<group>"; };
+		F71B6A6E1B48D4770041EB6D /* DispatcherEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DispatcherEventHandlerInterface.h; path = "../../../../Cinder-Asio/src/DispatcherEventHandlerInterface.h"; sourceTree = "<group>"; };
+		F71B6A6F1B48D4770041EB6D /* DispatcherInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DispatcherInterface.cpp; path = "../../../../Cinder-Asio/src/DispatcherInterface.cpp"; sourceTree = "<group>"; };
+		F71B6A701B48D4770041EB6D /* DispatcherInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DispatcherInterface.h; path = "../../../../Cinder-Asio/src/DispatcherInterface.h"; sourceTree = "<group>"; };
+		F71B6A711B48D4770041EB6D /* ServerEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ServerEventHandlerInterface.h; path = "../../../../Cinder-Asio/src/ServerEventHandlerInterface.h"; sourceTree = "<group>"; };
+		F71B6A721B48D4770041EB6D /* ServerInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ServerInterface.cpp; path = "../../../../Cinder-Asio/src/ServerInterface.cpp"; sourceTree = "<group>"; };
+		F71B6A731B48D4770041EB6D /* ServerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ServerInterface.h; path = "../../../../Cinder-Asio/src/ServerInterface.h"; sourceTree = "<group>"; };
+		F71B6A741B48D4770041EB6D /* SessionEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SessionEventHandlerInterface.h; path = "../../../../Cinder-Asio/src/SessionEventHandlerInterface.h"; sourceTree = "<group>"; };
+		F71B6A751B48D4770041EB6D /* SessionInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SessionInterface.cpp; path = "../../../../Cinder-Asio/src/SessionInterface.cpp"; sourceTree = "<group>"; };
+		F71B6A761B48D4770041EB6D /* SessionInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SessionInterface.h; path = "../../../../Cinder-Asio/src/SessionInterface.h"; sourceTree = "<group>"; };
+		F71B6A771B48D4770041EB6D /* TcpClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TcpClient.cpp; path = "../../../../Cinder-Asio/src/TcpClient.cpp"; sourceTree = "<group>"; };
+		F71B6A781B48D4770041EB6D /* TcpClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpClient.h; path = "../../../../Cinder-Asio/src/TcpClient.h"; sourceTree = "<group>"; };
+		F71B6A791B48D4770041EB6D /* TcpClientEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpClientEventHandlerInterface.h; path = "../../../../Cinder-Asio/src/TcpClientEventHandlerInterface.h"; sourceTree = "<group>"; };
+		F71B6A7A1B48D4770041EB6D /* TcpServer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TcpServer.cpp; path = "../../../../Cinder-Asio/src/TcpServer.cpp"; sourceTree = "<group>"; };
+		F71B6A7B1B48D4770041EB6D /* TcpServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpServer.h; path = "../../../../Cinder-Asio/src/TcpServer.h"; sourceTree = "<group>"; };
+		F71B6A7C1B48D4770041EB6D /* TcpServerEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpServerEventHandlerInterface.h; path = "../../../../Cinder-Asio/src/TcpServerEventHandlerInterface.h"; sourceTree = "<group>"; };
+		F71B6A7D1B48D4770041EB6D /* TcpSession.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TcpSession.cpp; path = "../../../../Cinder-Asio/src/TcpSession.cpp"; sourceTree = "<group>"; };
+		F71B6A7E1B48D4770041EB6D /* TcpSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpSession.h; path = "../../../../Cinder-Asio/src/TcpSession.h"; sourceTree = "<group>"; };
+		F71B6A7F1B48D4770041EB6D /* TcpSessionEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpSessionEventHandlerInterface.h; path = "../../../../Cinder-Asio/src/TcpSessionEventHandlerInterface.h"; sourceTree = "<group>"; };
+		F71B6A801B48D4770041EB6D /* UdpClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UdpClient.cpp; path = "../../../../Cinder-Asio/src/UdpClient.cpp"; sourceTree = "<group>"; };
+		F71B6A811B48D4770041EB6D /* UdpClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpClient.h; path = "../../../../Cinder-Asio/src/UdpClient.h"; sourceTree = "<group>"; };
+		F71B6A821B48D4770041EB6D /* UdpClientEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpClientEventHandlerInterface.h; path = "../../../../Cinder-Asio/src/UdpClientEventHandlerInterface.h"; sourceTree = "<group>"; };
+		F71B6A831B48D4770041EB6D /* UdpServer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UdpServer.cpp; path = "../../../../Cinder-Asio/src/UdpServer.cpp"; sourceTree = "<group>"; };
+		F71B6A841B48D4770041EB6D /* UdpServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpServer.h; path = "../../../../Cinder-Asio/src/UdpServer.h"; sourceTree = "<group>"; };
+		F71B6A851B48D4770041EB6D /* UdpServerEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpServerEventHandlerInterface.h; path = "../../../../Cinder-Asio/src/UdpServerEventHandlerInterface.h"; sourceTree = "<group>"; };
+		F71B6A861B48D4770041EB6D /* UdpSession.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UdpSession.cpp; path = "../../../../Cinder-Asio/src/UdpSession.cpp"; sourceTree = "<group>"; };
+		F71B6A871B48D4770041EB6D /* UdpSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpSession.h; path = "../../../../Cinder-Asio/src/UdpSession.h"; sourceTree = "<group>"; };
+		F71B6A881B48D4770041EB6D /* UdpSessionEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpSessionEventHandlerInterface.h; path = "../../../../Cinder-Asio/src/UdpSessionEventHandlerInterface.h"; sourceTree = "<group>"; };
+		F71B6A891B48D4770041EB6D /* WaitTimer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = WaitTimer.cpp; path = "../../../../Cinder-Asio/src/WaitTimer.cpp"; sourceTree = "<group>"; };
+		F71B6A8A1B48D4770041EB6D /* WaitTimer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WaitTimer.h; path = "../../../../Cinder-Asio/src/WaitTimer.h"; sourceTree = "<group>"; };
+		F71B6A8B1B48D4770041EB6D /* WaitTimerEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WaitTimerEventHandlerInterface.h; path = "../../../../Cinder-Asio/src/WaitTimerEventHandlerInterface.h"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -127,6 +136,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F71B6A661B48D4440041EB6D /* CoreMedia.framework in Frameworks */,
+				F71B6A671B48D4440041EB6D /* AVFoundation.framework in Frameworks */,
+				F71B6A681B48D4440041EB6D /* IOSurface.framework in Frameworks */,
+				F71B6A691B48D4440041EB6D /* IOKit.framework in Frameworks */,
 				8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */,
 				0091D8F90E81B9330029341E /* OpenGL.framework in Frameworks */,
 				5323E6B20EAFCA74003A9687 /* CoreVideo.framework in Frameworks */,
@@ -164,6 +177,10 @@
 		1058C7A0FEA54F0111CA2CBB /* Linked Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				F71B6A641B48D4350041EB6D /* CoreMedia.framework */,
+				F71B6A621B48D42F0041EB6D /* AVFoundation.framework */,
+				F71B6A601B48D4290041EB6D /* IOSurface.framework */,
+				F71B6A5E1B48D4220041EB6D /* IOKit.framework */,
 				00B784AF0FF439BC000DE1D7 /* Accelerate.framework */,
 				00B784B00FF439BC000DE1D7 /* AudioToolbox.framework */,
 				00B784B10FF439BC000DE1D7 /* AudioUnit.framework */,
@@ -267,39 +284,40 @@
 		AE9B2C861729C878003A950B /* Cinder-Asio */ = {
 			isa = PBXGroup;
 			children = (
-				AE84AC4919787C9400C32419 /* ClientEventHandlerInterface.h */,
-				AE84AC4A19787C9400C32419 /* ClientInterface.cpp */,
-				AE84AC4B19787C9400C32419 /* ClientInterface.h */,
-				AE84AC4C19787C9400C32419 /* DispatcherEventHandlerInterface.h */,
-				AE84AC4D19787C9400C32419 /* DispatcherInterface.cpp */,
-				AE84AC4E19787C9400C32419 /* DispatcherInterface.h */,
-				AE84AC4F19787C9400C32419 /* ServerEventHandlerInterface.h */,
-				AE84AC5019787C9400C32419 /* ServerInterface.cpp */,
-				AE84AC5119787C9400C32419 /* ServerInterface.h */,
-				AE84AC5219787C9400C32419 /* SessionEventHandlerInterface.h */,
-				AE84AC5319787C9400C32419 /* SessionInterface.cpp */,
-				AE84AC5419787C9400C32419 /* SessionInterface.h */,
-				AE84AC5519787C9400C32419 /* TcpClient.cpp */,
-				AE84AC5619787C9400C32419 /* TcpClient.h */,
-				AE84AC5719787C9400C32419 /* TcpClientEventHandlerInterface.h */,
-				AE84AC5819787C9400C32419 /* TcpServer.cpp */,
-				AE84AC5919787C9400C32419 /* TcpServer.h */,
-				AE84AC5A19787C9400C32419 /* TcpServerEventHandlerInterface.h */,
-				AE84AC5B19787C9400C32419 /* TcpSession.cpp */,
-				AE84AC5C19787C9400C32419 /* TcpSession.h */,
-				AE84AC5D19787C9400C32419 /* TcpSessionEventHandlerInterface.h */,
-				AE84AC5E19787C9400C32419 /* UdpClient.cpp */,
-				AE84AC5F19787C9400C32419 /* UdpClient.h */,
-				AE84AC6019787C9400C32419 /* UdpClientEventHandlerInterface.h */,
-				AE84AC6119787C9400C32419 /* UdpServer.cpp */,
-				AE84AC6219787C9400C32419 /* UdpServer.h */,
-				AE84AC6319787C9400C32419 /* UdpServerEventHandlerInterface.h */,
-				AE84AC6419787C9400C32419 /* UdpSession.cpp */,
-				AE84AC6519787C9400C32419 /* UdpSession.h */,
-				AE84AC6619787C9400C32419 /* UdpSessionEventHandlerInterface.h */,
-				AE84AC6719787C9400C32419 /* WaitTimer.cpp */,
-				AE84AC6819787C9400C32419 /* WaitTimer.h */,
-				AE84AC6919787C9400C32419 /* WaitTimerEventHandlerInterface.h */,
+				F71B6A6A1B48D4770041EB6D /* CinderAsio.h */,
+				F71B6A6B1B48D4770041EB6D /* ClientEventHandlerInterface.h */,
+				F71B6A6C1B48D4770041EB6D /* ClientInterface.cpp */,
+				F71B6A6D1B48D4770041EB6D /* ClientInterface.h */,
+				F71B6A6E1B48D4770041EB6D /* DispatcherEventHandlerInterface.h */,
+				F71B6A6F1B48D4770041EB6D /* DispatcherInterface.cpp */,
+				F71B6A701B48D4770041EB6D /* DispatcherInterface.h */,
+				F71B6A711B48D4770041EB6D /* ServerEventHandlerInterface.h */,
+				F71B6A721B48D4770041EB6D /* ServerInterface.cpp */,
+				F71B6A731B48D4770041EB6D /* ServerInterface.h */,
+				F71B6A741B48D4770041EB6D /* SessionEventHandlerInterface.h */,
+				F71B6A751B48D4770041EB6D /* SessionInterface.cpp */,
+				F71B6A761B48D4770041EB6D /* SessionInterface.h */,
+				F71B6A771B48D4770041EB6D /* TcpClient.cpp */,
+				F71B6A781B48D4770041EB6D /* TcpClient.h */,
+				F71B6A791B48D4770041EB6D /* TcpClientEventHandlerInterface.h */,
+				F71B6A7A1B48D4770041EB6D /* TcpServer.cpp */,
+				F71B6A7B1B48D4770041EB6D /* TcpServer.h */,
+				F71B6A7C1B48D4770041EB6D /* TcpServerEventHandlerInterface.h */,
+				F71B6A7D1B48D4770041EB6D /* TcpSession.cpp */,
+				F71B6A7E1B48D4770041EB6D /* TcpSession.h */,
+				F71B6A7F1B48D4770041EB6D /* TcpSessionEventHandlerInterface.h */,
+				F71B6A801B48D4770041EB6D /* UdpClient.cpp */,
+				F71B6A811B48D4770041EB6D /* UdpClient.h */,
+				F71B6A821B48D4770041EB6D /* UdpClientEventHandlerInterface.h */,
+				F71B6A831B48D4770041EB6D /* UdpServer.cpp */,
+				F71B6A841B48D4770041EB6D /* UdpServer.h */,
+				F71B6A851B48D4770041EB6D /* UdpServerEventHandlerInterface.h */,
+				F71B6A861B48D4770041EB6D /* UdpSession.cpp */,
+				F71B6A871B48D4770041EB6D /* UdpSession.h */,
+				F71B6A881B48D4770041EB6D /* UdpSessionEventHandlerInterface.h */,
+				F71B6A891B48D4770041EB6D /* WaitTimer.cpp */,
+				F71B6A8A1B48D4770041EB6D /* WaitTimer.h */,
+				F71B6A8B1B48D4770041EB6D /* WaitTimerEventHandlerInterface.h */,
 			);
 			name = "Cinder-Asio";
 			sourceTree = "<group>";
@@ -368,31 +386,31 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AE84AC7119787C9400C32419 /* UdpClient.cpp in Sources */,
+				F71B6A8D1B48D4770041EB6D /* DispatcherInterface.cpp in Sources */,
 				AECD95BB1990290C00FB1337 /* BodyInterface.cpp in Sources */,
-				AE84AC6A19787C9400C32419 /* ClientInterface.cpp in Sources */,
 				AECD95C11990290C00FB1337 /* HttpRequest.cpp in Sources */,
 				AECD95C01990290C00FB1337 /* HttpInterface.cpp in Sources */,
+				F71B6A941B48D4770041EB6D /* UdpServer.cpp in Sources */,
 				AECD95C31990290C00FB1337 /* KeyValuePairInterface.cpp in Sources */,
-				AE84AC6D19787C9400C32419 /* SessionInterface.cpp in Sources */,
-				AE84AC7019787C9400C32419 /* TcpSession.cpp in Sources */,
-				AE84AC7419787C9400C32419 /* WaitTimer.cpp in Sources */,
-				AE84AC7219787C9400C32419 /* UdpServer.cpp in Sources */,
-				AE84AC7319787C9400C32419 /* UdpSession.cpp in Sources */,
 				AECD95BC1990290C00FB1337 /* FtpInterface.cpp in Sources */,
 				AECD95A21990289B00FB1337 /* TcpSessionEventHandler.cpp in Sources */,
-				AE84AC6C19787C9400C32419 /* ServerInterface.cpp in Sources */,
 				AECD95A11990289B00FB1337 /* TcpClientEventHandler.cpp in Sources */,
 				AECD95BD1990290C00FB1337 /* FtpRequest.cpp in Sources */,
+				F71B6A961B48D4770041EB6D /* WaitTimer.cpp in Sources */,
 				AECD959F1990289B00FB1337 /* FtpClientApp.cpp in Sources */,
+				F71B6A8F1B48D4770041EB6D /* SessionInterface.cpp in Sources */,
+				F71B6A8E1B48D4770041EB6D /* ServerInterface.cpp in Sources */,
+				F71B6A901B48D4770041EB6D /* TcpClient.cpp in Sources */,
+				F71B6A8C1B48D4770041EB6D /* ClientInterface.cpp in Sources */,
 				AECD95BF1990290C00FB1337 /* HeaderInterface.cpp in Sources */,
 				AECD95BE1990290C00FB1337 /* FtpResponse.cpp in Sources */,
+				F71B6A911B48D4770041EB6D /* TcpServer.cpp in Sources */,
+				F71B6A921B48D4770041EB6D /* TcpSession.cpp in Sources */,
+				F71B6A931B48D4770041EB6D /* UdpClient.cpp in Sources */,
+				F71B6A951B48D4770041EB6D /* UdpSession.cpp in Sources */,
 				AECD95A01990289B00FB1337 /* TcpClientConnection.cpp in Sources */,
-				AE84AC6F19787C9400C32419 /* TcpServer.cpp in Sources */,
 				AECD95C41990290C00FB1337 /* ProtocolInterface.cpp in Sources */,
-				AE84AC6E19787C9400C32419 /* TcpClient.cpp in Sources */,
 				AECD95C21990290C00FB1337 /* HttpResponse.cpp in Sources */,
-				AE84AC6B19787C9400C32419 /* DispatcherInterface.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -416,11 +434,13 @@
 					"$(inherited)",
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\"";
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
 				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/libcinder_d.a\"";
 				PRODUCT_NAME = FtpClient;
 				SYMROOT = ./build;
+				USER_HEADER_SEARCH_PATHS = "$(CINDER_PATH)/include ../include ../../../src $(CINDER_PATH)/blocks/Cinder-Asio/src";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -439,12 +459,14 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = FtpClient_Prefix.pch;
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\"";
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
 				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/libcinder.a\"";
 				PRODUCT_NAME = FtpClient;
 				STRIP_INSTALLED_PRODUCT = YES;
 				SYMROOT = ./build;
+				USER_HEADER_SEARCH_PATHS = "$(CINDER_PATH)/include ../include ../../../src $(CINDER_PATH)/blocks/Cinder-Asio/src";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/samples/FtpClient/xcode/FtpClient_Prefix.pch
+++ b/samples/FtpClient/xcode/FtpClient_Prefix.pch
@@ -3,9 +3,11 @@
 #endif
 
 #if defined( __cplusplus )
+    #include "CinderAsio.h"
+
 	#include "cinder/Cinder.h"
 	
-	#include "cinder/app/AppBasic.h"
+	#include "cinder/app/App.h"
 	
 	#include "cinder/gl/gl.h"
 	

--- a/samples/HttpClient/src/HttpClientApp.cpp
+++ b/samples/HttpClient/src/HttpClientApp.cpp
@@ -71,7 +71,7 @@ private:
 	void						onClose();
 	void						onConnect( TcpSessionRef session );
 	void						onError( std::string err, size_t bytesTransferred );
-	void						onRead( ci::Buffer buffer );
+	void						onRead( ci::BufferRef buffer );
 	void						onResolve();
 	void						onWrite( size_t bytesTransferred );
 	
@@ -135,9 +135,9 @@ void HttpClientApp::onError( string err, size_t bytesTransferred )
 	mText.push_back( text );
 }
 
-void HttpClientApp::onRead( ci::Buffer buffer )
+void HttpClientApp::onRead( ci::BufferRef buffer )
 {
-	size_t sz	= buffer.getDataSize();
+	size_t sz	= buffer->getSize();
 	mBytesRead	+= sz;
 	mText.push_back( toString( sz ) + " bytes read" );
 	
@@ -240,7 +240,7 @@ void HttpClientApp::setup()
 
 	mParams = params::InterfaceGl::create( "Params", ivec2( 200, 150 ) );
 	mParams->addParam( "Frame rate",	&mFrameRate,			"", true );
-	mParams->addParam( "Full screen",	&mFullScreen.key( "f" ) );
+//	mParams->addParam( "Full screen",	&mFullScreen.key( "f" ) );
 	mParams->addParam( "Image index",	&mIndex,				"min=0 max=3 step=1 keyDecr=i keyIncr=I" );
 	mParams->addParam( "Host",			&mHost );
 	mParams->addButton( "Write",		[ & ]() { write(); },	"key=w" );
@@ -293,7 +293,7 @@ void HttpClientApp::write()
 	// Update request body
 	string index	= toString( mIndex );
 	mFilename		= index;
-	Buffer body		= HttpRequest::stringToBuffer( index );
+	BufferRef body	= HttpRequest::stringToBuffer( index );
 	mHttpRequest.setBody( body );
 	
 	mText.push_back( "Connecting to:\n" + mHost + ":2000" );

--- a/samples/HttpClient/src/HttpClientApp.cpp
+++ b/samples/HttpClient/src/HttpClientApp.cpp
@@ -240,7 +240,7 @@ void HttpClientApp::setup()
 
 	mParams = params::InterfaceGl::create( "Params", ivec2( 200, 150 ) );
 	mParams->addParam( "Frame rate",	&mFrameRate,			"", true );
-//	mParams->addParam( "Full screen",	&mFullScreen.key( "f" ) );
+	mParams->addParam( "Full screen",	&mFullScreen,           "key=f" );
 	mParams->addParam( "Image index",	&mIndex,				"min=0 max=3 step=1 keyDecr=i keyIncr=I" );
 	mParams->addParam( "Host",			&mHost );
 	mParams->addButton( "Write",		[ & ]() { write(); },	"key=w" );

--- a/samples/HttpClient/xcode/HttpClient.xcodeproj/project.pbxproj
+++ b/samples/HttpClient/xcode/HttpClient.xcodeproj/project.pbxproj
@@ -17,17 +17,6 @@
 		5323E6B60EAFCA7E003A9687 /* QTKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5323E6B50EAFCA7E003A9687 /* QTKit.framework */; };
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
 		94EE751DCA5C4F7A8CD38C63 /* CinderApp.icns in Resources */ = {isa = PBXBuildFile; fileRef = B14A5DB1785B4DB99B78CED8 /* CinderApp.icns */; };
-		AE84AC6A19787C9400C32419 /* ClientInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84AC4A19787C9400C32419 /* ClientInterface.cpp */; };
-		AE84AC6B19787C9400C32419 /* DispatcherInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84AC4D19787C9400C32419 /* DispatcherInterface.cpp */; };
-		AE84AC6C19787C9400C32419 /* ServerInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84AC5019787C9400C32419 /* ServerInterface.cpp */; };
-		AE84AC6D19787C9400C32419 /* SessionInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84AC5319787C9400C32419 /* SessionInterface.cpp */; };
-		AE84AC6E19787C9400C32419 /* TcpClient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84AC5519787C9400C32419 /* TcpClient.cpp */; };
-		AE84AC6F19787C9400C32419 /* TcpServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84AC5819787C9400C32419 /* TcpServer.cpp */; };
-		AE84AC7019787C9400C32419 /* TcpSession.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84AC5B19787C9400C32419 /* TcpSession.cpp */; };
-		AE84AC7119787C9400C32419 /* UdpClient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84AC5E19787C9400C32419 /* UdpClient.cpp */; };
-		AE84AC7219787C9400C32419 /* UdpServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84AC6119787C9400C32419 /* UdpServer.cpp */; };
-		AE84AC7319787C9400C32419 /* UdpSession.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84AC6419787C9400C32419 /* UdpSession.cpp */; };
-		AE84AC7419787C9400C32419 /* WaitTimer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84AC6719787C9400C32419 /* WaitTimer.cpp */; };
 		AECD95D91990292A00FB1337 /* BodyInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AECD95C51990292A00FB1337 /* BodyInterface.cpp */; };
 		AECD95DA1990292A00FB1337 /* FtpInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AECD95C71990292A00FB1337 /* FtpInterface.cpp */; };
 		AECD95DB1990292A00FB1337 /* FtpRequest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AECD95C91990292A00FB1337 /* FtpRequest.cpp */; };
@@ -38,6 +27,17 @@
 		AECD95E01990292A00FB1337 /* HttpResponse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AECD95D31990292A00FB1337 /* HttpResponse.cpp */; };
 		AECD95E11990292A00FB1337 /* KeyValuePairInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AECD95D51990292A00FB1337 /* KeyValuePairInterface.cpp */; };
 		AECD95E21990292A00FB1337 /* ProtocolInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AECD95D71990292A00FB1337 /* ProtocolInterface.cpp */; };
+		F7E963661B48C22D00A13777 /* ClientInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7E963461B48C22D00A13777 /* ClientInterface.cpp */; };
+		F7E963671B48C22D00A13777 /* DispatcherInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7E963491B48C22D00A13777 /* DispatcherInterface.cpp */; };
+		F7E963681B48C22D00A13777 /* ServerInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7E9634C1B48C22D00A13777 /* ServerInterface.cpp */; };
+		F7E963691B48C22D00A13777 /* SessionInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7E9634F1B48C22D00A13777 /* SessionInterface.cpp */; };
+		F7E9636A1B48C22D00A13777 /* TcpClient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7E963511B48C22D00A13777 /* TcpClient.cpp */; };
+		F7E9636B1B48C22D00A13777 /* TcpServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7E963541B48C22D00A13777 /* TcpServer.cpp */; };
+		F7E9636C1B48C22D00A13777 /* TcpSession.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7E963571B48C22D00A13777 /* TcpSession.cpp */; };
+		F7E9636D1B48C22D00A13777 /* UdpClient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7E9635A1B48C22D00A13777 /* UdpClient.cpp */; };
+		F7E9636E1B48C22D00A13777 /* UdpServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7E9635D1B48C22D00A13777 /* UdpServer.cpp */; };
+		F7E9636F1B48C22D00A13777 /* UdpSession.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7E963601B48C22D00A13777 /* UdpSession.cpp */; };
+		F7E963701B48C22D00A13777 /* WaitTimer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7E963631B48C22D00A13777 /* WaitTimer.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -55,39 +55,6 @@
 		5323E6B10EAFCA74003A9687 /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = /System/Library/Frameworks/CoreVideo.framework; sourceTree = "<absolute>"; };
 		5323E6B50EAFCA7E003A9687 /* QTKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QTKit.framework; path = /System/Library/Frameworks/QTKit.framework; sourceTree = "<absolute>"; };
 		8D1107320486CEB800E47090 /* HttpClient.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HttpClient.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		AE84AC4919787C9400C32419 /* ClientEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ClientEventHandlerInterface.h; path = "../../../blocks/Cinder-Asio/src/ClientEventHandlerInterface.h"; sourceTree = "<group>"; };
-		AE84AC4A19787C9400C32419 /* ClientInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ClientInterface.cpp; path = "../../../blocks/Cinder-Asio/src/ClientInterface.cpp"; sourceTree = "<group>"; };
-		AE84AC4B19787C9400C32419 /* ClientInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ClientInterface.h; path = "../../../blocks/Cinder-Asio/src/ClientInterface.h"; sourceTree = "<group>"; };
-		AE84AC4C19787C9400C32419 /* DispatcherEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DispatcherEventHandlerInterface.h; path = "../../../blocks/Cinder-Asio/src/DispatcherEventHandlerInterface.h"; sourceTree = "<group>"; };
-		AE84AC4D19787C9400C32419 /* DispatcherInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DispatcherInterface.cpp; path = "../../../blocks/Cinder-Asio/src/DispatcherInterface.cpp"; sourceTree = "<group>"; };
-		AE84AC4E19787C9400C32419 /* DispatcherInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DispatcherInterface.h; path = "../../../blocks/Cinder-Asio/src/DispatcherInterface.h"; sourceTree = "<group>"; };
-		AE84AC4F19787C9400C32419 /* ServerEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ServerEventHandlerInterface.h; path = "../../../blocks/Cinder-Asio/src/ServerEventHandlerInterface.h"; sourceTree = "<group>"; };
-		AE84AC5019787C9400C32419 /* ServerInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ServerInterface.cpp; path = "../../../blocks/Cinder-Asio/src/ServerInterface.cpp"; sourceTree = "<group>"; };
-		AE84AC5119787C9400C32419 /* ServerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ServerInterface.h; path = "../../../blocks/Cinder-Asio/src/ServerInterface.h"; sourceTree = "<group>"; };
-		AE84AC5219787C9400C32419 /* SessionEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SessionEventHandlerInterface.h; path = "../../../blocks/Cinder-Asio/src/SessionEventHandlerInterface.h"; sourceTree = "<group>"; };
-		AE84AC5319787C9400C32419 /* SessionInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SessionInterface.cpp; path = "../../../blocks/Cinder-Asio/src/SessionInterface.cpp"; sourceTree = "<group>"; };
-		AE84AC5419787C9400C32419 /* SessionInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SessionInterface.h; path = "../../../blocks/Cinder-Asio/src/SessionInterface.h"; sourceTree = "<group>"; };
-		AE84AC5519787C9400C32419 /* TcpClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TcpClient.cpp; path = "../../../blocks/Cinder-Asio/src/TcpClient.cpp"; sourceTree = "<group>"; };
-		AE84AC5619787C9400C32419 /* TcpClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpClient.h; path = "../../../blocks/Cinder-Asio/src/TcpClient.h"; sourceTree = "<group>"; };
-		AE84AC5719787C9400C32419 /* TcpClientEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpClientEventHandlerInterface.h; path = "../../../blocks/Cinder-Asio/src/TcpClientEventHandlerInterface.h"; sourceTree = "<group>"; };
-		AE84AC5819787C9400C32419 /* TcpServer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TcpServer.cpp; path = "../../../blocks/Cinder-Asio/src/TcpServer.cpp"; sourceTree = "<group>"; };
-		AE84AC5919787C9400C32419 /* TcpServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpServer.h; path = "../../../blocks/Cinder-Asio/src/TcpServer.h"; sourceTree = "<group>"; };
-		AE84AC5A19787C9400C32419 /* TcpServerEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpServerEventHandlerInterface.h; path = "../../../blocks/Cinder-Asio/src/TcpServerEventHandlerInterface.h"; sourceTree = "<group>"; };
-		AE84AC5B19787C9400C32419 /* TcpSession.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TcpSession.cpp; path = "../../../blocks/Cinder-Asio/src/TcpSession.cpp"; sourceTree = "<group>"; };
-		AE84AC5C19787C9400C32419 /* TcpSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpSession.h; path = "../../../blocks/Cinder-Asio/src/TcpSession.h"; sourceTree = "<group>"; };
-		AE84AC5D19787C9400C32419 /* TcpSessionEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpSessionEventHandlerInterface.h; path = "../../../blocks/Cinder-Asio/src/TcpSessionEventHandlerInterface.h"; sourceTree = "<group>"; };
-		AE84AC5E19787C9400C32419 /* UdpClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UdpClient.cpp; path = "../../../blocks/Cinder-Asio/src/UdpClient.cpp"; sourceTree = "<group>"; };
-		AE84AC5F19787C9400C32419 /* UdpClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpClient.h; path = "../../../blocks/Cinder-Asio/src/UdpClient.h"; sourceTree = "<group>"; };
-		AE84AC6019787C9400C32419 /* UdpClientEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpClientEventHandlerInterface.h; path = "../../../blocks/Cinder-Asio/src/UdpClientEventHandlerInterface.h"; sourceTree = "<group>"; };
-		AE84AC6119787C9400C32419 /* UdpServer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UdpServer.cpp; path = "../../../blocks/Cinder-Asio/src/UdpServer.cpp"; sourceTree = "<group>"; };
-		AE84AC6219787C9400C32419 /* UdpServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpServer.h; path = "../../../blocks/Cinder-Asio/src/UdpServer.h"; sourceTree = "<group>"; };
-		AE84AC6319787C9400C32419 /* UdpServerEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpServerEventHandlerInterface.h; path = "../../../blocks/Cinder-Asio/src/UdpServerEventHandlerInterface.h"; sourceTree = "<group>"; };
-		AE84AC6419787C9400C32419 /* UdpSession.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UdpSession.cpp; path = "../../../blocks/Cinder-Asio/src/UdpSession.cpp"; sourceTree = "<group>"; };
-		AE84AC6519787C9400C32419 /* UdpSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpSession.h; path = "../../../blocks/Cinder-Asio/src/UdpSession.h"; sourceTree = "<group>"; };
-		AE84AC6619787C9400C32419 /* UdpSessionEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpSessionEventHandlerInterface.h; path = "../../../blocks/Cinder-Asio/src/UdpSessionEventHandlerInterface.h"; sourceTree = "<group>"; };
-		AE84AC6719787C9400C32419 /* WaitTimer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = WaitTimer.cpp; path = "../../../blocks/Cinder-Asio/src/WaitTimer.cpp"; sourceTree = "<group>"; };
-		AE84AC6819787C9400C32419 /* WaitTimer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WaitTimer.h; path = "../../../blocks/Cinder-Asio/src/WaitTimer.h"; sourceTree = "<group>"; };
-		AE84AC6919787C9400C32419 /* WaitTimerEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WaitTimerEventHandlerInterface.h; path = "../../../blocks/Cinder-Asio/src/WaitTimerEventHandlerInterface.h"; sourceTree = "<group>"; };
 		AECD95C51990292A00FB1337 /* BodyInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = BodyInterface.cpp; path = ../../../src/BodyInterface.cpp; sourceTree = "<group>"; };
 		AECD95C61990292A00FB1337 /* BodyInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BodyInterface.h; path = ../../../src/BodyInterface.h; sourceTree = "<group>"; };
 		AECD95C71990292A00FB1337 /* FtpInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FtpInterface.cpp; path = ../../../src/FtpInterface.cpp; sourceTree = "<group>"; };
@@ -110,6 +77,40 @@
 		AECD95D81990292A00FB1337 /* ProtocolInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ProtocolInterface.h; path = ../../../src/ProtocolInterface.h; sourceTree = "<group>"; };
 		B14A5DB1785B4DB99B78CED8 /* CinderApp.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = CinderApp.icns; path = ../resources/CinderApp.icns; sourceTree = "<group>"; };
 		E3D5E373F4DE4E91A2494A2F /* HttpClientApp.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = HttpClientApp.cpp; path = ../src/HttpClientApp.cpp; sourceTree = "<group>"; };
+		F7E963441B48C22D00A13777 /* CinderAsio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CinderAsio.h; path = "../../../../Cinder-Asio/src/CinderAsio.h"; sourceTree = "<group>"; };
+		F7E963451B48C22D00A13777 /* ClientEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ClientEventHandlerInterface.h; path = "../../../../Cinder-Asio/src/ClientEventHandlerInterface.h"; sourceTree = "<group>"; };
+		F7E963461B48C22D00A13777 /* ClientInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ClientInterface.cpp; path = "../../../../Cinder-Asio/src/ClientInterface.cpp"; sourceTree = "<group>"; };
+		F7E963471B48C22D00A13777 /* ClientInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ClientInterface.h; path = "../../../../Cinder-Asio/src/ClientInterface.h"; sourceTree = "<group>"; };
+		F7E963481B48C22D00A13777 /* DispatcherEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DispatcherEventHandlerInterface.h; path = "../../../../Cinder-Asio/src/DispatcherEventHandlerInterface.h"; sourceTree = "<group>"; };
+		F7E963491B48C22D00A13777 /* DispatcherInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DispatcherInterface.cpp; path = "../../../../Cinder-Asio/src/DispatcherInterface.cpp"; sourceTree = "<group>"; };
+		F7E9634A1B48C22D00A13777 /* DispatcherInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DispatcherInterface.h; path = "../../../../Cinder-Asio/src/DispatcherInterface.h"; sourceTree = "<group>"; };
+		F7E9634B1B48C22D00A13777 /* ServerEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ServerEventHandlerInterface.h; path = "../../../../Cinder-Asio/src/ServerEventHandlerInterface.h"; sourceTree = "<group>"; };
+		F7E9634C1B48C22D00A13777 /* ServerInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ServerInterface.cpp; path = "../../../../Cinder-Asio/src/ServerInterface.cpp"; sourceTree = "<group>"; };
+		F7E9634D1B48C22D00A13777 /* ServerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ServerInterface.h; path = "../../../../Cinder-Asio/src/ServerInterface.h"; sourceTree = "<group>"; };
+		F7E9634E1B48C22D00A13777 /* SessionEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SessionEventHandlerInterface.h; path = "../../../../Cinder-Asio/src/SessionEventHandlerInterface.h"; sourceTree = "<group>"; };
+		F7E9634F1B48C22D00A13777 /* SessionInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SessionInterface.cpp; path = "../../../../Cinder-Asio/src/SessionInterface.cpp"; sourceTree = "<group>"; };
+		F7E963501B48C22D00A13777 /* SessionInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SessionInterface.h; path = "../../../../Cinder-Asio/src/SessionInterface.h"; sourceTree = "<group>"; };
+		F7E963511B48C22D00A13777 /* TcpClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TcpClient.cpp; path = "../../../../Cinder-Asio/src/TcpClient.cpp"; sourceTree = "<group>"; };
+		F7E963521B48C22D00A13777 /* TcpClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpClient.h; path = "../../../../Cinder-Asio/src/TcpClient.h"; sourceTree = "<group>"; };
+		F7E963531B48C22D00A13777 /* TcpClientEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpClientEventHandlerInterface.h; path = "../../../../Cinder-Asio/src/TcpClientEventHandlerInterface.h"; sourceTree = "<group>"; };
+		F7E963541B48C22D00A13777 /* TcpServer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TcpServer.cpp; path = "../../../../Cinder-Asio/src/TcpServer.cpp"; sourceTree = "<group>"; };
+		F7E963551B48C22D00A13777 /* TcpServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpServer.h; path = "../../../../Cinder-Asio/src/TcpServer.h"; sourceTree = "<group>"; };
+		F7E963561B48C22D00A13777 /* TcpServerEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpServerEventHandlerInterface.h; path = "../../../../Cinder-Asio/src/TcpServerEventHandlerInterface.h"; sourceTree = "<group>"; };
+		F7E963571B48C22D00A13777 /* TcpSession.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TcpSession.cpp; path = "../../../../Cinder-Asio/src/TcpSession.cpp"; sourceTree = "<group>"; };
+		F7E963581B48C22D00A13777 /* TcpSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpSession.h; path = "../../../../Cinder-Asio/src/TcpSession.h"; sourceTree = "<group>"; };
+		F7E963591B48C22D00A13777 /* TcpSessionEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpSessionEventHandlerInterface.h; path = "../../../../Cinder-Asio/src/TcpSessionEventHandlerInterface.h"; sourceTree = "<group>"; };
+		F7E9635A1B48C22D00A13777 /* UdpClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UdpClient.cpp; path = "../../../../Cinder-Asio/src/UdpClient.cpp"; sourceTree = "<group>"; };
+		F7E9635B1B48C22D00A13777 /* UdpClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpClient.h; path = "../../../../Cinder-Asio/src/UdpClient.h"; sourceTree = "<group>"; };
+		F7E9635C1B48C22D00A13777 /* UdpClientEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpClientEventHandlerInterface.h; path = "../../../../Cinder-Asio/src/UdpClientEventHandlerInterface.h"; sourceTree = "<group>"; };
+		F7E9635D1B48C22D00A13777 /* UdpServer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UdpServer.cpp; path = "../../../../Cinder-Asio/src/UdpServer.cpp"; sourceTree = "<group>"; };
+		F7E9635E1B48C22D00A13777 /* UdpServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpServer.h; path = "../../../../Cinder-Asio/src/UdpServer.h"; sourceTree = "<group>"; };
+		F7E9635F1B48C22D00A13777 /* UdpServerEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpServerEventHandlerInterface.h; path = "../../../../Cinder-Asio/src/UdpServerEventHandlerInterface.h"; sourceTree = "<group>"; };
+		F7E963601B48C22D00A13777 /* UdpSession.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UdpSession.cpp; path = "../../../../Cinder-Asio/src/UdpSession.cpp"; sourceTree = "<group>"; };
+		F7E963611B48C22D00A13777 /* UdpSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpSession.h; path = "../../../../Cinder-Asio/src/UdpSession.h"; sourceTree = "<group>"; };
+		F7E963621B48C22D00A13777 /* UdpSessionEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpSessionEventHandlerInterface.h; path = "../../../../Cinder-Asio/src/UdpSessionEventHandlerInterface.h"; sourceTree = "<group>"; };
+		F7E963631B48C22D00A13777 /* WaitTimer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = WaitTimer.cpp; path = "../../../../Cinder-Asio/src/WaitTimer.cpp"; sourceTree = "<group>"; };
+		F7E963641B48C22D00A13777 /* WaitTimer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WaitTimer.h; path = "../../../../Cinder-Asio/src/WaitTimer.h"; sourceTree = "<group>"; };
+		F7E963651B48C22D00A13777 /* WaitTimerEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WaitTimerEventHandlerInterface.h; path = "../../../../Cinder-Asio/src/WaitTimerEventHandlerInterface.h"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -250,39 +251,40 @@
 		AE9B2C861729C878003A950B /* Cinder-Asio */ = {
 			isa = PBXGroup;
 			children = (
-				AE84AC4919787C9400C32419 /* ClientEventHandlerInterface.h */,
-				AE84AC4A19787C9400C32419 /* ClientInterface.cpp */,
-				AE84AC4B19787C9400C32419 /* ClientInterface.h */,
-				AE84AC4C19787C9400C32419 /* DispatcherEventHandlerInterface.h */,
-				AE84AC4D19787C9400C32419 /* DispatcherInterface.cpp */,
-				AE84AC4E19787C9400C32419 /* DispatcherInterface.h */,
-				AE84AC4F19787C9400C32419 /* ServerEventHandlerInterface.h */,
-				AE84AC5019787C9400C32419 /* ServerInterface.cpp */,
-				AE84AC5119787C9400C32419 /* ServerInterface.h */,
-				AE84AC5219787C9400C32419 /* SessionEventHandlerInterface.h */,
-				AE84AC5319787C9400C32419 /* SessionInterface.cpp */,
-				AE84AC5419787C9400C32419 /* SessionInterface.h */,
-				AE84AC5519787C9400C32419 /* TcpClient.cpp */,
-				AE84AC5619787C9400C32419 /* TcpClient.h */,
-				AE84AC5719787C9400C32419 /* TcpClientEventHandlerInterface.h */,
-				AE84AC5819787C9400C32419 /* TcpServer.cpp */,
-				AE84AC5919787C9400C32419 /* TcpServer.h */,
-				AE84AC5A19787C9400C32419 /* TcpServerEventHandlerInterface.h */,
-				AE84AC5B19787C9400C32419 /* TcpSession.cpp */,
-				AE84AC5C19787C9400C32419 /* TcpSession.h */,
-				AE84AC5D19787C9400C32419 /* TcpSessionEventHandlerInterface.h */,
-				AE84AC5E19787C9400C32419 /* UdpClient.cpp */,
-				AE84AC5F19787C9400C32419 /* UdpClient.h */,
-				AE84AC6019787C9400C32419 /* UdpClientEventHandlerInterface.h */,
-				AE84AC6119787C9400C32419 /* UdpServer.cpp */,
-				AE84AC6219787C9400C32419 /* UdpServer.h */,
-				AE84AC6319787C9400C32419 /* UdpServerEventHandlerInterface.h */,
-				AE84AC6419787C9400C32419 /* UdpSession.cpp */,
-				AE84AC6519787C9400C32419 /* UdpSession.h */,
-				AE84AC6619787C9400C32419 /* UdpSessionEventHandlerInterface.h */,
-				AE84AC6719787C9400C32419 /* WaitTimer.cpp */,
-				AE84AC6819787C9400C32419 /* WaitTimer.h */,
-				AE84AC6919787C9400C32419 /* WaitTimerEventHandlerInterface.h */,
+				F7E963441B48C22D00A13777 /* CinderAsio.h */,
+				F7E963451B48C22D00A13777 /* ClientEventHandlerInterface.h */,
+				F7E963461B48C22D00A13777 /* ClientInterface.cpp */,
+				F7E963471B48C22D00A13777 /* ClientInterface.h */,
+				F7E963481B48C22D00A13777 /* DispatcherEventHandlerInterface.h */,
+				F7E963491B48C22D00A13777 /* DispatcherInterface.cpp */,
+				F7E9634A1B48C22D00A13777 /* DispatcherInterface.h */,
+				F7E9634B1B48C22D00A13777 /* ServerEventHandlerInterface.h */,
+				F7E9634C1B48C22D00A13777 /* ServerInterface.cpp */,
+				F7E9634D1B48C22D00A13777 /* ServerInterface.h */,
+				F7E9634E1B48C22D00A13777 /* SessionEventHandlerInterface.h */,
+				F7E9634F1B48C22D00A13777 /* SessionInterface.cpp */,
+				F7E963501B48C22D00A13777 /* SessionInterface.h */,
+				F7E963511B48C22D00A13777 /* TcpClient.cpp */,
+				F7E963521B48C22D00A13777 /* TcpClient.h */,
+				F7E963531B48C22D00A13777 /* TcpClientEventHandlerInterface.h */,
+				F7E963541B48C22D00A13777 /* TcpServer.cpp */,
+				F7E963551B48C22D00A13777 /* TcpServer.h */,
+				F7E963561B48C22D00A13777 /* TcpServerEventHandlerInterface.h */,
+				F7E963571B48C22D00A13777 /* TcpSession.cpp */,
+				F7E963581B48C22D00A13777 /* TcpSession.h */,
+				F7E963591B48C22D00A13777 /* TcpSessionEventHandlerInterface.h */,
+				F7E9635A1B48C22D00A13777 /* UdpClient.cpp */,
+				F7E9635B1B48C22D00A13777 /* UdpClient.h */,
+				F7E9635C1B48C22D00A13777 /* UdpClientEventHandlerInterface.h */,
+				F7E9635D1B48C22D00A13777 /* UdpServer.cpp */,
+				F7E9635E1B48C22D00A13777 /* UdpServer.h */,
+				F7E9635F1B48C22D00A13777 /* UdpServerEventHandlerInterface.h */,
+				F7E963601B48C22D00A13777 /* UdpSession.cpp */,
+				F7E963611B48C22D00A13777 /* UdpSession.h */,
+				F7E963621B48C22D00A13777 /* UdpSessionEventHandlerInterface.h */,
+				F7E963631B48C22D00A13777 /* WaitTimer.cpp */,
+				F7E963641B48C22D00A13777 /* WaitTimer.h */,
+				F7E963651B48C22D00A13777 /* WaitTimerEventHandlerInterface.h */,
 			);
 			name = "Cinder-Asio";
 			sourceTree = "<group>";
@@ -350,28 +352,28 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F7E963661B48C22D00A13777 /* ClientInterface.cpp in Sources */,
 				AECD95E01990292A00FB1337 /* HttpResponse.cpp in Sources */,
-				AE84AC7119787C9400C32419 /* UdpClient.cpp in Sources */,
-				AE84AC6A19787C9400C32419 /* ClientInterface.cpp in Sources */,
+				F7E9636E1B48C22D00A13777 /* UdpServer.cpp in Sources */,
 				AECD95E21990292A00FB1337 /* ProtocolInterface.cpp in Sources */,
-				AE84AC6D19787C9400C32419 /* SessionInterface.cpp in Sources */,
 				AECD95DD1990292A00FB1337 /* HeaderInterface.cpp in Sources */,
+				F7E9636A1B48C22D00A13777 /* TcpClient.cpp in Sources */,
+				F7E963691B48C22D00A13777 /* SessionInterface.cpp in Sources */,
+				F7E9636B1B48C22D00A13777 /* TcpServer.cpp in Sources */,
+				F7E963701B48C22D00A13777 /* WaitTimer.cpp in Sources */,
 				AECD95DB1990292A00FB1337 /* FtpRequest.cpp in Sources */,
-				AE84AC7019787C9400C32419 /* TcpSession.cpp in Sources */,
+				F7E9636C1B48C22D00A13777 /* TcpSession.cpp in Sources */,
+				F7E9636D1B48C22D00A13777 /* UdpClient.cpp in Sources */,
 				AECD95DA1990292A00FB1337 /* FtpInterface.cpp in Sources */,
 				AECD95DF1990292A00FB1337 /* HttpRequest.cpp in Sources */,
 				AECD95D91990292A00FB1337 /* BodyInterface.cpp in Sources */,
-				AE84AC7419787C9400C32419 /* WaitTimer.cpp in Sources */,
+				F7E963681B48C22D00A13777 /* ServerInterface.cpp in Sources */,
 				343EF4E06FF341EF9A78DA51 /* HttpClientApp.cpp in Sources */,
 				AECD95DC1990292A00FB1337 /* FtpResponse.cpp in Sources */,
-				AE84AC7219787C9400C32419 /* UdpServer.cpp in Sources */,
+				F7E9636F1B48C22D00A13777 /* UdpSession.cpp in Sources */,
 				AECD95E11990292A00FB1337 /* KeyValuePairInterface.cpp in Sources */,
-				AE84AC7319787C9400C32419 /* UdpSession.cpp in Sources */,
-				AE84AC6C19787C9400C32419 /* ServerInterface.cpp in Sources */,
-				AE84AC6F19787C9400C32419 /* TcpServer.cpp in Sources */,
 				AECD95DE1990292A00FB1337 /* HttpInterface.cpp in Sources */,
-				AE84AC6E19787C9400C32419 /* TcpClient.cpp in Sources */,
-				AE84AC6B19787C9400C32419 /* DispatcherInterface.cpp in Sources */,
+				F7E963671B48C22D00A13777 /* DispatcherInterface.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -395,11 +397,13 @@
 					"$(inherited)",
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\"";
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
 				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/libcinder_d.a\"";
 				PRODUCT_NAME = HttpClient;
 				SYMROOT = ./build;
+				USER_HEADER_SEARCH_PATHS = "$(CINDER_PATH)/include ../include ../../../src $(CINDER_PATH)/blocks/Cinder-Asio/src";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -418,12 +422,14 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = HttpClient_Prefix.pch;
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\"";
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
 				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/libcinder.a\"";
 				PRODUCT_NAME = HttpClient;
 				STRIP_INSTALLED_PRODUCT = YES;
 				SYMROOT = ./build;
+				USER_HEADER_SEARCH_PATHS = "$(CINDER_PATH)/include ../include ../../../src $(CINDER_PATH)/blocks/Cinder-Asio/src";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/samples/HttpClient/xcode/HttpClient.xcodeproj/project.pbxproj
+++ b/samples/HttpClient/xcode/HttpClient.xcodeproj/project.pbxproj
@@ -456,13 +456,16 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
 				CINDER_PATH = ../../../../..;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/boost\"";
+				HEADER_SEARCH_PATHS = (
+					"\"$(CINDER_PATH)/include\"",
+					/usr/local/include,
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				SDKROOT = macosx;
 				USER_HEADER_SEARCH_PATHS = "$(CINDER_PATH)/include ../include ../../../src ../../../blocks/Cinder-Asio/src";
@@ -473,13 +476,16 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
 				CINDER_PATH = ../../../../..;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/boost\"";
+				HEADER_SEARCH_PATHS = (
+					"\"$(CINDER_PATH)/include\"",
+					/usr/local/include,
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				SDKROOT = macosx;
 				USER_HEADER_SEARCH_PATHS = "$(CINDER_PATH)/include ../include ../../../src ../../../blocks/Cinder-Asio/src";

--- a/samples/HttpClient/xcode/HttpClient.xcodeproj/project.pbxproj
+++ b/samples/HttpClient/xcode/HttpClient.xcodeproj/project.pbxproj
@@ -399,7 +399,7 @@
 		C01FCF4B08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
 				CINDER_PATH = ../../../../..;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
@@ -428,7 +428,7 @@
 		C01FCF4C08A954540054247B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
 				CINDER_PATH = ../../../../..;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;

--- a/samples/HttpClient/xcode/HttpClient.xcodeproj/project.pbxproj
+++ b/samples/HttpClient/xcode/HttpClient.xcodeproj/project.pbxproj
@@ -38,6 +38,10 @@
 		F7E9636E1B48C22D00A13777 /* UdpServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7E9635D1B48C22D00A13777 /* UdpServer.cpp */; };
 		F7E9636F1B48C22D00A13777 /* UdpSession.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7E963601B48C22D00A13777 /* UdpSession.cpp */; };
 		F7E963701B48C22D00A13777 /* WaitTimer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7E963631B48C22D00A13777 /* WaitTimer.cpp */; };
+		F7E963791B48C80900A13777 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F7E963771B48C7DF00A13777 /* CoreMedia.framework */; };
+		F7E9637A1B48C80900A13777 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F7E963751B48C7CE00A13777 /* AVFoundation.framework */; };
+		F7E9637B1B48C80900A13777 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F7E963731B48C7B800A13777 /* IOSurface.framework */; };
+		F7E9637C1B48C80900A13777 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F7E963711B48C7AE00A13777 /* IOKit.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -111,6 +115,10 @@
 		F7E963631B48C22D00A13777 /* WaitTimer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = WaitTimer.cpp; path = "../../../../Cinder-Asio/src/WaitTimer.cpp"; sourceTree = "<group>"; };
 		F7E963641B48C22D00A13777 /* WaitTimer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WaitTimer.h; path = "../../../../Cinder-Asio/src/WaitTimer.h"; sourceTree = "<group>"; };
 		F7E963651B48C22D00A13777 /* WaitTimerEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WaitTimerEventHandlerInterface.h; path = "../../../../Cinder-Asio/src/WaitTimerEventHandlerInterface.h"; sourceTree = "<group>"; };
+		F7E963711B48C7AE00A13777 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
+		F7E963731B48C7B800A13777 /* IOSurface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOSurface.framework; path = System/Library/Frameworks/IOSurface.framework; sourceTree = SDKROOT; };
+		F7E963751B48C7CE00A13777 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
+		F7E963771B48C7DF00A13777 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -118,6 +126,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F7E963791B48C80900A13777 /* CoreMedia.framework in Frameworks */,
+				F7E9637A1B48C80900A13777 /* AVFoundation.framework in Frameworks */,
+				F7E9637B1B48C80900A13777 /* IOSurface.framework in Frameworks */,
+				F7E9637C1B48C80900A13777 /* IOKit.framework in Frameworks */,
 				8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */,
 				0091D8F90E81B9330029341E /* OpenGL.framework in Frameworks */,
 				5323E6B20EAFCA74003A9687 /* CoreVideo.framework in Frameworks */,
@@ -152,6 +164,10 @@
 		1058C7A0FEA54F0111CA2CBB /* Linked Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				F7E963771B48C7DF00A13777 /* CoreMedia.framework */,
+				F7E963751B48C7CE00A13777 /* AVFoundation.framework */,
+				F7E963731B48C7B800A13777 /* IOSurface.framework */,
+				F7E963711B48C7AE00A13777 /* IOKit.framework */,
 				00B784AF0FF439BC000DE1D7 /* Accelerate.framework */,
 				00B784B00FF439BC000DE1D7 /* AudioToolbox.framework */,
 				00B784B10FF439BC000DE1D7 /* AudioUnit.framework */,
@@ -383,6 +399,7 @@
 		C01FCF4B08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CINDER_PATH = ../../../../..;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
@@ -411,6 +428,7 @@
 		C01FCF4C08A954540054247B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CINDER_PATH = ../../../../..;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;

--- a/samples/HttpClient/xcode/HttpClient_Prefix.pch
+++ b/samples/HttpClient/xcode/HttpClient_Prefix.pch
@@ -3,9 +3,11 @@
 #endif
 
 #if defined( __cplusplus )
+    #include "CinderAsio.h"
+
 	#include "cinder/Cinder.h"
 	
-	#include "cinder/app/AppBasic.h"
+	#include "cinder/app/App.h"
 	
 	#include "cinder/gl/gl.h"
 	

--- a/samples/HttpServer/src/HttpServerApp.cpp
+++ b/samples/HttpServer/src/HttpServerApp.cpp
@@ -66,7 +66,7 @@ private:
 	void						onCancel();
 	void						onClose();
 	void						onError( std::string err, size_t bytesTransferred );
-	void						onRead( ci::Buffer buffer );
+	void						onRead( ci::BufferRef buffer );
 	void						onWrite( size_t bytesTransferred );
 	
 	ci::Font					mFont;
@@ -146,9 +146,9 @@ void HttpServerApp::onError( string err, size_t bytesTransferred )
 	mText.push_back( text );
 }
 
-void HttpServerApp::onRead( ci::Buffer buffer )
+void HttpServerApp::onRead( ci::BufferRef buffer )
 {
-	mText.push_back( toString( buffer.getDataSize() ) + " bytes read" );
+	mText.push_back( toString( buffer->getSize() ) + " bytes read" );
 	
 	// Parse the request buffer into headers and body
 	mHttpRequest.parse( buffer );
@@ -170,7 +170,7 @@ void HttpServerApp::onRead( ci::Buffer buffer )
 	mHttpResponse.setHttpVersion( HttpVersion::HTTP_1_1 );
 	
 	// Declare an empty response body
-	Buffer body;
+	BufferRef body;
 
 	if ( index < 0 || index > 2 ) {
 		
@@ -215,7 +215,7 @@ void HttpServerApp::onRead( ci::Buffer buffer )
 	
 	// Set the content length using the body size
 	mHttpResponse.setBody( body );
-	size_t sz = body.getDataSize();
+	size_t sz = body->getSize();
 	mHttpResponse.setHeader( "Content-Length", toString( sz ) );
 	
 	// Tell the client to close the connection when they're finished
@@ -243,7 +243,7 @@ void HttpServerApp::setup()
 	
 	mParams = params::InterfaceGl::create( "Params", ivec2( 200, 150 ) );
 	mParams->addParam( "Frame rate",	&mFrameRate,					"", true );
-	mParams->addParam( "Full screen",	&mFullScreen.key( "f" ) );
+	mParams->addParam( "Full screen",	&mFullScreen,                   "key=f" );
 	mParams->addButton( "Quit", bind(	&HttpServerApp::quit, this ),	"key=q" );
 	
 	mServer = TcpServer::create( io_service() );

--- a/samples/HttpServer/xcode/HttpServer.xcodeproj/project.pbxproj
+++ b/samples/HttpServer/xcode/HttpServer.xcodeproj/project.pbxproj
@@ -16,17 +16,6 @@
 		5323E6B60EAFCA7E003A9687 /* QTKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5323E6B50EAFCA7E003A9687 /* QTKit.framework */; };
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
 		94EE751DCA5C4F7A8CD38C63 /* CinderApp.icns in Resources */ = {isa = PBXBuildFile; fileRef = B14A5DB1785B4DB99B78CED8 /* CinderApp.icns */; };
-		AE84AC6A19787C9400C32419 /* ClientInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84AC4A19787C9400C32419 /* ClientInterface.cpp */; };
-		AE84AC6B19787C9400C32419 /* DispatcherInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84AC4D19787C9400C32419 /* DispatcherInterface.cpp */; };
-		AE84AC6C19787C9400C32419 /* ServerInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84AC5019787C9400C32419 /* ServerInterface.cpp */; };
-		AE84AC6D19787C9400C32419 /* SessionInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84AC5319787C9400C32419 /* SessionInterface.cpp */; };
-		AE84AC6E19787C9400C32419 /* TcpClient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84AC5519787C9400C32419 /* TcpClient.cpp */; };
-		AE84AC6F19787C9400C32419 /* TcpServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84AC5819787C9400C32419 /* TcpServer.cpp */; };
-		AE84AC7019787C9400C32419 /* TcpSession.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84AC5B19787C9400C32419 /* TcpSession.cpp */; };
-		AE84AC7119787C9400C32419 /* UdpClient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84AC5E19787C9400C32419 /* UdpClient.cpp */; };
-		AE84AC7219787C9400C32419 /* UdpServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84AC6119787C9400C32419 /* UdpServer.cpp */; };
-		AE84AC7319787C9400C32419 /* UdpSession.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84AC6419787C9400C32419 /* UdpSession.cpp */; };
-		AE84AC7419787C9400C32419 /* WaitTimer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE84AC6719787C9400C32419 /* WaitTimer.cpp */; };
 		AEB0448F197D808100D5AB01 /* HttpServerApp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AEB0448E197D808100D5AB01 /* HttpServerApp.cpp */; };
 		AECD95F71990294500FB1337 /* BodyInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AECD95E31990294500FB1337 /* BodyInterface.cpp */; };
 		AECD95F81990294500FB1337 /* FtpInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AECD95E51990294500FB1337 /* FtpInterface.cpp */; };
@@ -38,6 +27,21 @@
 		AECD95FE1990294500FB1337 /* HttpResponse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AECD95F11990294500FB1337 /* HttpResponse.cpp */; };
 		AECD95FF1990294500FB1337 /* KeyValuePairInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AECD95F31990294500FB1337 /* KeyValuePairInterface.cpp */; };
 		AECD96001990294500FB1337 /* ProtocolInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AECD95F51990294500FB1337 /* ProtocolInterface.cpp */; };
+		F7AC77901B4A0F5600C21833 /* ClientInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7AC77701B4A0F5600C21833 /* ClientInterface.cpp */; };
+		F7AC77911B4A0F5600C21833 /* DispatcherInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7AC77731B4A0F5600C21833 /* DispatcherInterface.cpp */; };
+		F7AC77921B4A0F5600C21833 /* ServerInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7AC77761B4A0F5600C21833 /* ServerInterface.cpp */; };
+		F7AC77931B4A0F5600C21833 /* SessionInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7AC77791B4A0F5600C21833 /* SessionInterface.cpp */; };
+		F7AC77941B4A0F5600C21833 /* TcpClient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7AC777B1B4A0F5600C21833 /* TcpClient.cpp */; };
+		F7AC77951B4A0F5600C21833 /* TcpServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7AC777E1B4A0F5600C21833 /* TcpServer.cpp */; };
+		F7AC77961B4A0F5600C21833 /* TcpSession.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7AC77811B4A0F5600C21833 /* TcpSession.cpp */; };
+		F7AC77971B4A0F5600C21833 /* UdpClient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7AC77841B4A0F5600C21833 /* UdpClient.cpp */; };
+		F7AC77981B4A0F5600C21833 /* UdpServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7AC77871B4A0F5600C21833 /* UdpServer.cpp */; };
+		F7AC77991B4A0F5600C21833 /* UdpSession.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7AC778A1B4A0F5600C21833 /* UdpSession.cpp */; };
+		F7AC779A1B4A0F5600C21833 /* WaitTimer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7AC778D1B4A0F5600C21833 /* WaitTimer.cpp */; };
+		F7AC77A31B4A113300C21833 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F7AC77A11B4A110600C21833 /* CoreMedia.framework */; };
+		F7AC77A41B4A113300C21833 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F7AC779F1B4A10FF00C21833 /* IOSurface.framework */; };
+		F7AC77A51B4A113300C21833 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F7AC779D1B4A10F900C21833 /* AVFoundation.framework */; };
+		F7AC77A61B4A113300C21833 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F7AC779B1B4A10F200C21833 /* IOKit.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -55,39 +59,6 @@
 		5323E6B10EAFCA74003A9687 /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = /System/Library/Frameworks/CoreVideo.framework; sourceTree = "<absolute>"; };
 		5323E6B50EAFCA7E003A9687 /* QTKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QTKit.framework; path = /System/Library/Frameworks/QTKit.framework; sourceTree = "<absolute>"; };
 		8D1107320486CEB800E47090 /* HttpServer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HttpServer.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		AE84AC4919787C9400C32419 /* ClientEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ClientEventHandlerInterface.h; path = "../../../blocks/Cinder-Asio/src/ClientEventHandlerInterface.h"; sourceTree = "<group>"; };
-		AE84AC4A19787C9400C32419 /* ClientInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ClientInterface.cpp; path = "../../../blocks/Cinder-Asio/src/ClientInterface.cpp"; sourceTree = "<group>"; };
-		AE84AC4B19787C9400C32419 /* ClientInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ClientInterface.h; path = "../../../blocks/Cinder-Asio/src/ClientInterface.h"; sourceTree = "<group>"; };
-		AE84AC4C19787C9400C32419 /* DispatcherEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DispatcherEventHandlerInterface.h; path = "../../../blocks/Cinder-Asio/src/DispatcherEventHandlerInterface.h"; sourceTree = "<group>"; };
-		AE84AC4D19787C9400C32419 /* DispatcherInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DispatcherInterface.cpp; path = "../../../blocks/Cinder-Asio/src/DispatcherInterface.cpp"; sourceTree = "<group>"; };
-		AE84AC4E19787C9400C32419 /* DispatcherInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DispatcherInterface.h; path = "../../../blocks/Cinder-Asio/src/DispatcherInterface.h"; sourceTree = "<group>"; };
-		AE84AC4F19787C9400C32419 /* ServerEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ServerEventHandlerInterface.h; path = "../../../blocks/Cinder-Asio/src/ServerEventHandlerInterface.h"; sourceTree = "<group>"; };
-		AE84AC5019787C9400C32419 /* ServerInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ServerInterface.cpp; path = "../../../blocks/Cinder-Asio/src/ServerInterface.cpp"; sourceTree = "<group>"; };
-		AE84AC5119787C9400C32419 /* ServerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ServerInterface.h; path = "../../../blocks/Cinder-Asio/src/ServerInterface.h"; sourceTree = "<group>"; };
-		AE84AC5219787C9400C32419 /* SessionEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SessionEventHandlerInterface.h; path = "../../../blocks/Cinder-Asio/src/SessionEventHandlerInterface.h"; sourceTree = "<group>"; };
-		AE84AC5319787C9400C32419 /* SessionInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SessionInterface.cpp; path = "../../../blocks/Cinder-Asio/src/SessionInterface.cpp"; sourceTree = "<group>"; };
-		AE84AC5419787C9400C32419 /* SessionInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SessionInterface.h; path = "../../../blocks/Cinder-Asio/src/SessionInterface.h"; sourceTree = "<group>"; };
-		AE84AC5519787C9400C32419 /* TcpClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TcpClient.cpp; path = "../../../blocks/Cinder-Asio/src/TcpClient.cpp"; sourceTree = "<group>"; };
-		AE84AC5619787C9400C32419 /* TcpClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpClient.h; path = "../../../blocks/Cinder-Asio/src/TcpClient.h"; sourceTree = "<group>"; };
-		AE84AC5719787C9400C32419 /* TcpClientEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpClientEventHandlerInterface.h; path = "../../../blocks/Cinder-Asio/src/TcpClientEventHandlerInterface.h"; sourceTree = "<group>"; };
-		AE84AC5819787C9400C32419 /* TcpServer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TcpServer.cpp; path = "../../../blocks/Cinder-Asio/src/TcpServer.cpp"; sourceTree = "<group>"; };
-		AE84AC5919787C9400C32419 /* TcpServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpServer.h; path = "../../../blocks/Cinder-Asio/src/TcpServer.h"; sourceTree = "<group>"; };
-		AE84AC5A19787C9400C32419 /* TcpServerEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpServerEventHandlerInterface.h; path = "../../../blocks/Cinder-Asio/src/TcpServerEventHandlerInterface.h"; sourceTree = "<group>"; };
-		AE84AC5B19787C9400C32419 /* TcpSession.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TcpSession.cpp; path = "../../../blocks/Cinder-Asio/src/TcpSession.cpp"; sourceTree = "<group>"; };
-		AE84AC5C19787C9400C32419 /* TcpSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpSession.h; path = "../../../blocks/Cinder-Asio/src/TcpSession.h"; sourceTree = "<group>"; };
-		AE84AC5D19787C9400C32419 /* TcpSessionEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpSessionEventHandlerInterface.h; path = "../../../blocks/Cinder-Asio/src/TcpSessionEventHandlerInterface.h"; sourceTree = "<group>"; };
-		AE84AC5E19787C9400C32419 /* UdpClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UdpClient.cpp; path = "../../../blocks/Cinder-Asio/src/UdpClient.cpp"; sourceTree = "<group>"; };
-		AE84AC5F19787C9400C32419 /* UdpClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpClient.h; path = "../../../blocks/Cinder-Asio/src/UdpClient.h"; sourceTree = "<group>"; };
-		AE84AC6019787C9400C32419 /* UdpClientEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpClientEventHandlerInterface.h; path = "../../../blocks/Cinder-Asio/src/UdpClientEventHandlerInterface.h"; sourceTree = "<group>"; };
-		AE84AC6119787C9400C32419 /* UdpServer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UdpServer.cpp; path = "../../../blocks/Cinder-Asio/src/UdpServer.cpp"; sourceTree = "<group>"; };
-		AE84AC6219787C9400C32419 /* UdpServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpServer.h; path = "../../../blocks/Cinder-Asio/src/UdpServer.h"; sourceTree = "<group>"; };
-		AE84AC6319787C9400C32419 /* UdpServerEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpServerEventHandlerInterface.h; path = "../../../blocks/Cinder-Asio/src/UdpServerEventHandlerInterface.h"; sourceTree = "<group>"; };
-		AE84AC6419787C9400C32419 /* UdpSession.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UdpSession.cpp; path = "../../../blocks/Cinder-Asio/src/UdpSession.cpp"; sourceTree = "<group>"; };
-		AE84AC6519787C9400C32419 /* UdpSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpSession.h; path = "../../../blocks/Cinder-Asio/src/UdpSession.h"; sourceTree = "<group>"; };
-		AE84AC6619787C9400C32419 /* UdpSessionEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpSessionEventHandlerInterface.h; path = "../../../blocks/Cinder-Asio/src/UdpSessionEventHandlerInterface.h"; sourceTree = "<group>"; };
-		AE84AC6719787C9400C32419 /* WaitTimer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = WaitTimer.cpp; path = "../../../blocks/Cinder-Asio/src/WaitTimer.cpp"; sourceTree = "<group>"; };
-		AE84AC6819787C9400C32419 /* WaitTimer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WaitTimer.h; path = "../../../blocks/Cinder-Asio/src/WaitTimer.h"; sourceTree = "<group>"; };
-		AE84AC6919787C9400C32419 /* WaitTimerEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WaitTimerEventHandlerInterface.h; path = "../../../blocks/Cinder-Asio/src/WaitTimerEventHandlerInterface.h"; sourceTree = "<group>"; };
 		AEB0448E197D808100D5AB01 /* HttpServerApp.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = HttpServerApp.cpp; path = ../src/HttpServerApp.cpp; sourceTree = "<group>"; };
 		AECD95E31990294500FB1337 /* BodyInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = BodyInterface.cpp; path = ../../../src/BodyInterface.cpp; sourceTree = "<group>"; };
 		AECD95E41990294500FB1337 /* BodyInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BodyInterface.h; path = ../../../src/BodyInterface.h; sourceTree = "<group>"; };
@@ -110,6 +81,44 @@
 		AECD95F51990294500FB1337 /* ProtocolInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ProtocolInterface.cpp; path = ../../../src/ProtocolInterface.cpp; sourceTree = "<group>"; };
 		AECD95F61990294500FB1337 /* ProtocolInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ProtocolInterface.h; path = ../../../src/ProtocolInterface.h; sourceTree = "<group>"; };
 		B14A5DB1785B4DB99B78CED8 /* CinderApp.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = CinderApp.icns; path = ../resources/CinderApp.icns; sourceTree = "<group>"; };
+		F7AC776E1B4A0F5600C21833 /* CinderAsio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CinderAsio.h; path = "../../../../Cinder-Asio/src/CinderAsio.h"; sourceTree = "<group>"; };
+		F7AC776F1B4A0F5600C21833 /* ClientEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ClientEventHandlerInterface.h; path = "../../../../Cinder-Asio/src/ClientEventHandlerInterface.h"; sourceTree = "<group>"; };
+		F7AC77701B4A0F5600C21833 /* ClientInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ClientInterface.cpp; path = "../../../../Cinder-Asio/src/ClientInterface.cpp"; sourceTree = "<group>"; };
+		F7AC77711B4A0F5600C21833 /* ClientInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ClientInterface.h; path = "../../../../Cinder-Asio/src/ClientInterface.h"; sourceTree = "<group>"; };
+		F7AC77721B4A0F5600C21833 /* DispatcherEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DispatcherEventHandlerInterface.h; path = "../../../../Cinder-Asio/src/DispatcherEventHandlerInterface.h"; sourceTree = "<group>"; };
+		F7AC77731B4A0F5600C21833 /* DispatcherInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DispatcherInterface.cpp; path = "../../../../Cinder-Asio/src/DispatcherInterface.cpp"; sourceTree = "<group>"; };
+		F7AC77741B4A0F5600C21833 /* DispatcherInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DispatcherInterface.h; path = "../../../../Cinder-Asio/src/DispatcherInterface.h"; sourceTree = "<group>"; };
+		F7AC77751B4A0F5600C21833 /* ServerEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ServerEventHandlerInterface.h; path = "../../../../Cinder-Asio/src/ServerEventHandlerInterface.h"; sourceTree = "<group>"; };
+		F7AC77761B4A0F5600C21833 /* ServerInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ServerInterface.cpp; path = "../../../../Cinder-Asio/src/ServerInterface.cpp"; sourceTree = "<group>"; };
+		F7AC77771B4A0F5600C21833 /* ServerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ServerInterface.h; path = "../../../../Cinder-Asio/src/ServerInterface.h"; sourceTree = "<group>"; };
+		F7AC77781B4A0F5600C21833 /* SessionEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SessionEventHandlerInterface.h; path = "../../../../Cinder-Asio/src/SessionEventHandlerInterface.h"; sourceTree = "<group>"; };
+		F7AC77791B4A0F5600C21833 /* SessionInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SessionInterface.cpp; path = "../../../../Cinder-Asio/src/SessionInterface.cpp"; sourceTree = "<group>"; };
+		F7AC777A1B4A0F5600C21833 /* SessionInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SessionInterface.h; path = "../../../../Cinder-Asio/src/SessionInterface.h"; sourceTree = "<group>"; };
+		F7AC777B1B4A0F5600C21833 /* TcpClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TcpClient.cpp; path = "../../../../Cinder-Asio/src/TcpClient.cpp"; sourceTree = "<group>"; };
+		F7AC777C1B4A0F5600C21833 /* TcpClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpClient.h; path = "../../../../Cinder-Asio/src/TcpClient.h"; sourceTree = "<group>"; };
+		F7AC777D1B4A0F5600C21833 /* TcpClientEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpClientEventHandlerInterface.h; path = "../../../../Cinder-Asio/src/TcpClientEventHandlerInterface.h"; sourceTree = "<group>"; };
+		F7AC777E1B4A0F5600C21833 /* TcpServer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TcpServer.cpp; path = "../../../../Cinder-Asio/src/TcpServer.cpp"; sourceTree = "<group>"; };
+		F7AC777F1B4A0F5600C21833 /* TcpServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpServer.h; path = "../../../../Cinder-Asio/src/TcpServer.h"; sourceTree = "<group>"; };
+		F7AC77801B4A0F5600C21833 /* TcpServerEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpServerEventHandlerInterface.h; path = "../../../../Cinder-Asio/src/TcpServerEventHandlerInterface.h"; sourceTree = "<group>"; };
+		F7AC77811B4A0F5600C21833 /* TcpSession.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TcpSession.cpp; path = "../../../../Cinder-Asio/src/TcpSession.cpp"; sourceTree = "<group>"; };
+		F7AC77821B4A0F5600C21833 /* TcpSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpSession.h; path = "../../../../Cinder-Asio/src/TcpSession.h"; sourceTree = "<group>"; };
+		F7AC77831B4A0F5600C21833 /* TcpSessionEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TcpSessionEventHandlerInterface.h; path = "../../../../Cinder-Asio/src/TcpSessionEventHandlerInterface.h"; sourceTree = "<group>"; };
+		F7AC77841B4A0F5600C21833 /* UdpClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UdpClient.cpp; path = "../../../../Cinder-Asio/src/UdpClient.cpp"; sourceTree = "<group>"; };
+		F7AC77851B4A0F5600C21833 /* UdpClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpClient.h; path = "../../../../Cinder-Asio/src/UdpClient.h"; sourceTree = "<group>"; };
+		F7AC77861B4A0F5600C21833 /* UdpClientEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpClientEventHandlerInterface.h; path = "../../../../Cinder-Asio/src/UdpClientEventHandlerInterface.h"; sourceTree = "<group>"; };
+		F7AC77871B4A0F5600C21833 /* UdpServer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UdpServer.cpp; path = "../../../../Cinder-Asio/src/UdpServer.cpp"; sourceTree = "<group>"; };
+		F7AC77881B4A0F5600C21833 /* UdpServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpServer.h; path = "../../../../Cinder-Asio/src/UdpServer.h"; sourceTree = "<group>"; };
+		F7AC77891B4A0F5600C21833 /* UdpServerEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpServerEventHandlerInterface.h; path = "../../../../Cinder-Asio/src/UdpServerEventHandlerInterface.h"; sourceTree = "<group>"; };
+		F7AC778A1B4A0F5600C21833 /* UdpSession.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UdpSession.cpp; path = "../../../../Cinder-Asio/src/UdpSession.cpp"; sourceTree = "<group>"; };
+		F7AC778B1B4A0F5600C21833 /* UdpSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpSession.h; path = "../../../../Cinder-Asio/src/UdpSession.h"; sourceTree = "<group>"; };
+		F7AC778C1B4A0F5600C21833 /* UdpSessionEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UdpSessionEventHandlerInterface.h; path = "../../../../Cinder-Asio/src/UdpSessionEventHandlerInterface.h"; sourceTree = "<group>"; };
+		F7AC778D1B4A0F5600C21833 /* WaitTimer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = WaitTimer.cpp; path = "../../../../Cinder-Asio/src/WaitTimer.cpp"; sourceTree = "<group>"; };
+		F7AC778E1B4A0F5600C21833 /* WaitTimer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WaitTimer.h; path = "../../../../Cinder-Asio/src/WaitTimer.h"; sourceTree = "<group>"; };
+		F7AC778F1B4A0F5600C21833 /* WaitTimerEventHandlerInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WaitTimerEventHandlerInterface.h; path = "../../../../Cinder-Asio/src/WaitTimerEventHandlerInterface.h"; sourceTree = "<group>"; };
+		F7AC779B1B4A10F200C21833 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
+		F7AC779D1B4A10F900C21833 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
+		F7AC779F1B4A10FF00C21833 /* IOSurface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOSurface.framework; path = System/Library/Frameworks/IOSurface.framework; sourceTree = SDKROOT; };
+		F7AC77A11B4A110600C21833 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -117,6 +126,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F7AC77A31B4A113300C21833 /* CoreMedia.framework in Frameworks */,
+				F7AC77A41B4A113300C21833 /* IOSurface.framework in Frameworks */,
+				F7AC77A51B4A113300C21833 /* AVFoundation.framework in Frameworks */,
+				F7AC77A61B4A113300C21833 /* IOKit.framework in Frameworks */,
 				8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */,
 				0091D8F90E81B9330029341E /* OpenGL.framework in Frameworks */,
 				5323E6B20EAFCA74003A9687 /* CoreVideo.framework in Frameworks */,
@@ -151,6 +164,10 @@
 		1058C7A0FEA54F0111CA2CBB /* Linked Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				F7AC77A11B4A110600C21833 /* CoreMedia.framework */,
+				F7AC779F1B4A10FF00C21833 /* IOSurface.framework */,
+				F7AC779D1B4A10F900C21833 /* AVFoundation.framework */,
+				F7AC779B1B4A10F200C21833 /* IOKit.framework */,
 				00B784AF0FF439BC000DE1D7 /* Accelerate.framework */,
 				00B784B00FF439BC000DE1D7 /* AudioToolbox.framework */,
 				00B784B10FF439BC000DE1D7 /* AudioUnit.framework */,
@@ -250,39 +267,40 @@
 		AE9B2C861729C878003A950B /* Cinder-Asio */ = {
 			isa = PBXGroup;
 			children = (
-				AE84AC4919787C9400C32419 /* ClientEventHandlerInterface.h */,
-				AE84AC4A19787C9400C32419 /* ClientInterface.cpp */,
-				AE84AC4B19787C9400C32419 /* ClientInterface.h */,
-				AE84AC4C19787C9400C32419 /* DispatcherEventHandlerInterface.h */,
-				AE84AC4D19787C9400C32419 /* DispatcherInterface.cpp */,
-				AE84AC4E19787C9400C32419 /* DispatcherInterface.h */,
-				AE84AC4F19787C9400C32419 /* ServerEventHandlerInterface.h */,
-				AE84AC5019787C9400C32419 /* ServerInterface.cpp */,
-				AE84AC5119787C9400C32419 /* ServerInterface.h */,
-				AE84AC5219787C9400C32419 /* SessionEventHandlerInterface.h */,
-				AE84AC5319787C9400C32419 /* SessionInterface.cpp */,
-				AE84AC5419787C9400C32419 /* SessionInterface.h */,
-				AE84AC5519787C9400C32419 /* TcpClient.cpp */,
-				AE84AC5619787C9400C32419 /* TcpClient.h */,
-				AE84AC5719787C9400C32419 /* TcpClientEventHandlerInterface.h */,
-				AE84AC5819787C9400C32419 /* TcpServer.cpp */,
-				AE84AC5919787C9400C32419 /* TcpServer.h */,
-				AE84AC5A19787C9400C32419 /* TcpServerEventHandlerInterface.h */,
-				AE84AC5B19787C9400C32419 /* TcpSession.cpp */,
-				AE84AC5C19787C9400C32419 /* TcpSession.h */,
-				AE84AC5D19787C9400C32419 /* TcpSessionEventHandlerInterface.h */,
-				AE84AC5E19787C9400C32419 /* UdpClient.cpp */,
-				AE84AC5F19787C9400C32419 /* UdpClient.h */,
-				AE84AC6019787C9400C32419 /* UdpClientEventHandlerInterface.h */,
-				AE84AC6119787C9400C32419 /* UdpServer.cpp */,
-				AE84AC6219787C9400C32419 /* UdpServer.h */,
-				AE84AC6319787C9400C32419 /* UdpServerEventHandlerInterface.h */,
-				AE84AC6419787C9400C32419 /* UdpSession.cpp */,
-				AE84AC6519787C9400C32419 /* UdpSession.h */,
-				AE84AC6619787C9400C32419 /* UdpSessionEventHandlerInterface.h */,
-				AE84AC6719787C9400C32419 /* WaitTimer.cpp */,
-				AE84AC6819787C9400C32419 /* WaitTimer.h */,
-				AE84AC6919787C9400C32419 /* WaitTimerEventHandlerInterface.h */,
+				F7AC776E1B4A0F5600C21833 /* CinderAsio.h */,
+				F7AC776F1B4A0F5600C21833 /* ClientEventHandlerInterface.h */,
+				F7AC77701B4A0F5600C21833 /* ClientInterface.cpp */,
+				F7AC77711B4A0F5600C21833 /* ClientInterface.h */,
+				F7AC77721B4A0F5600C21833 /* DispatcherEventHandlerInterface.h */,
+				F7AC77731B4A0F5600C21833 /* DispatcherInterface.cpp */,
+				F7AC77741B4A0F5600C21833 /* DispatcherInterface.h */,
+				F7AC77751B4A0F5600C21833 /* ServerEventHandlerInterface.h */,
+				F7AC77761B4A0F5600C21833 /* ServerInterface.cpp */,
+				F7AC77771B4A0F5600C21833 /* ServerInterface.h */,
+				F7AC77781B4A0F5600C21833 /* SessionEventHandlerInterface.h */,
+				F7AC77791B4A0F5600C21833 /* SessionInterface.cpp */,
+				F7AC777A1B4A0F5600C21833 /* SessionInterface.h */,
+				F7AC777B1B4A0F5600C21833 /* TcpClient.cpp */,
+				F7AC777C1B4A0F5600C21833 /* TcpClient.h */,
+				F7AC777D1B4A0F5600C21833 /* TcpClientEventHandlerInterface.h */,
+				F7AC777E1B4A0F5600C21833 /* TcpServer.cpp */,
+				F7AC777F1B4A0F5600C21833 /* TcpServer.h */,
+				F7AC77801B4A0F5600C21833 /* TcpServerEventHandlerInterface.h */,
+				F7AC77811B4A0F5600C21833 /* TcpSession.cpp */,
+				F7AC77821B4A0F5600C21833 /* TcpSession.h */,
+				F7AC77831B4A0F5600C21833 /* TcpSessionEventHandlerInterface.h */,
+				F7AC77841B4A0F5600C21833 /* UdpClient.cpp */,
+				F7AC77851B4A0F5600C21833 /* UdpClient.h */,
+				F7AC77861B4A0F5600C21833 /* UdpClientEventHandlerInterface.h */,
+				F7AC77871B4A0F5600C21833 /* UdpServer.cpp */,
+				F7AC77881B4A0F5600C21833 /* UdpServer.h */,
+				F7AC77891B4A0F5600C21833 /* UdpServerEventHandlerInterface.h */,
+				F7AC778A1B4A0F5600C21833 /* UdpSession.cpp */,
+				F7AC778B1B4A0F5600C21833 /* UdpSession.h */,
+				F7AC778C1B4A0F5600C21833 /* UdpSessionEventHandlerInterface.h */,
+				F7AC778D1B4A0F5600C21833 /* WaitTimer.cpp */,
+				F7AC778E1B4A0F5600C21833 /* WaitTimer.h */,
+				F7AC778F1B4A0F5600C21833 /* WaitTimerEventHandlerInterface.h */,
 			);
 			name = "Cinder-Asio";
 			sourceTree = "<group>";
@@ -350,28 +368,28 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F7AC77901B4A0F5600C21833 /* ClientInterface.cpp in Sources */,
 				AECD95FE1990294500FB1337 /* HttpResponse.cpp in Sources */,
-				AE84AC7119787C9400C32419 /* UdpClient.cpp in Sources */,
-				AE84AC6A19787C9400C32419 /* ClientInterface.cpp in Sources */,
+				F7AC77981B4A0F5600C21833 /* UdpServer.cpp in Sources */,
 				AECD96001990294500FB1337 /* ProtocolInterface.cpp in Sources */,
-				AE84AC6D19787C9400C32419 /* SessionInterface.cpp in Sources */,
 				AECD95FB1990294500FB1337 /* HeaderInterface.cpp in Sources */,
+				F7AC77941B4A0F5600C21833 /* TcpClient.cpp in Sources */,
+				F7AC77931B4A0F5600C21833 /* SessionInterface.cpp in Sources */,
+				F7AC77951B4A0F5600C21833 /* TcpServer.cpp in Sources */,
+				F7AC779A1B4A0F5600C21833 /* WaitTimer.cpp in Sources */,
 				AECD95F91990294500FB1337 /* FtpRequest.cpp in Sources */,
-				AE84AC7019787C9400C32419 /* TcpSession.cpp in Sources */,
+				F7AC77961B4A0F5600C21833 /* TcpSession.cpp in Sources */,
+				F7AC77971B4A0F5600C21833 /* UdpClient.cpp in Sources */,
 				AECD95F81990294500FB1337 /* FtpInterface.cpp in Sources */,
 				AECD95FD1990294500FB1337 /* HttpRequest.cpp in Sources */,
 				AECD95F71990294500FB1337 /* BodyInterface.cpp in Sources */,
-				AE84AC7419787C9400C32419 /* WaitTimer.cpp in Sources */,
-				AE84AC7219787C9400C32419 /* UdpServer.cpp in Sources */,
+				F7AC77921B4A0F5600C21833 /* ServerInterface.cpp in Sources */,
 				AECD95FA1990294500FB1337 /* FtpResponse.cpp in Sources */,
-				AE84AC7319787C9400C32419 /* UdpSession.cpp in Sources */,
 				AECD95FF1990294500FB1337 /* KeyValuePairInterface.cpp in Sources */,
-				AE84AC6C19787C9400C32419 /* ServerInterface.cpp in Sources */,
+				F7AC77991B4A0F5600C21833 /* UdpSession.cpp in Sources */,
 				AEB0448F197D808100D5AB01 /* HttpServerApp.cpp in Sources */,
-				AE84AC6F19787C9400C32419 /* TcpServer.cpp in Sources */,
 				AECD95FC1990294500FB1337 /* HttpInterface.cpp in Sources */,
-				AE84AC6E19787C9400C32419 /* TcpClient.cpp in Sources */,
-				AE84AC6B19787C9400C32419 /* DispatcherInterface.cpp in Sources */,
+				F7AC77911B4A0F5600C21833 /* DispatcherInterface.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -381,6 +399,7 @@
 		C01FCF4B08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
 				CINDER_PATH = ../../../../..;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
@@ -395,6 +414,7 @@
 					"$(inherited)",
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\"";
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
 				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/libcinder_d.a\"";
@@ -407,6 +427,7 @@
 		C01FCF4C08A954540054247B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
 				CINDER_PATH = ../../../../..;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
@@ -418,6 +439,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = HttpServer_Prefix.pch;
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\"";
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
 				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/libcinder.a\"";

--- a/samples/HttpServer/xcode/HttpServer_Prefix.pch
+++ b/samples/HttpServer/xcode/HttpServer_Prefix.pch
@@ -3,9 +3,11 @@
 #endif
 
 #if defined( __cplusplus )
+    #include "CinderAsio.h"
+
 	#include "cinder/Cinder.h"
 	
-	#include "cinder/app/AppBasic.h"
+	#include "cinder/app/App.h"
 	
 	#include "cinder/gl/gl.h"
 	

--- a/src/BodyInterface.cpp
+++ b/src/BodyInterface.cpp
@@ -49,36 +49,36 @@ BodyInterface::BodyInterface()
 {
 }
 
-void BodyInterface::append( const ci::Buffer& buffer )
+void BodyInterface::append( const ci::BufferRef& buffer )
 {
 	size_t sz	= 0;
-	size_t len	= buffer.getDataSize();
+	size_t len	= buffer->getSize();
 	if ( mBody ) {
-		sz = mBody.getDataSize();
-		mBody.resize( sz + len );
+		sz = mBody->getSize();
+		mBody->resize( sz + len );
 	} else {
-		mBody = Buffer( len );
+        mBody = Buffer::create( len );
 	}
-	char_traits<char>::copy( (char*)mBody.getData() + sz, (char*)buffer.getData(), len );
+	char_traits<char>::copy( (char*)mBody->getData() + sz, (char*)buffer->getData(), len );
 }
 
-const Buffer& BodyInterface::getBody() const
+const BufferRef& BodyInterface::getBody() const
 {
 	return mBody;
 }
 
-void BodyInterface::setBody( const Buffer& body )
+void BodyInterface::setBody( const BufferRef& body )
 {
-	size_t sz = body.getDataSize();
+	size_t sz = body->getSize();
 	if ( mBody && sz > 0 ) {
-		mBody.resize( sz );
+		mBody->resize( sz );
 	} else {
-		mBody = Buffer( sz );
+        mBody = Buffer::create( sz );
 	}
-	char_traits<char>::copy( (char*)mBody.getData(), (char*)body.getData(), sz );
+	char_traits<char>::copy( (char*)mBody->getData(), (char*)body->getData(), sz );
 }
 
-Buffer BodyInterface::toBuffer() const
+BufferRef BodyInterface::toBuffer() const
 {
 	return mBody;
 }

--- a/src/BodyInterface.h
+++ b/src/BodyInterface.h
@@ -43,19 +43,19 @@ class BodyInterface : public ProtocolInterface
 {
 public:
 	//! Appends \a buffer to body.
-	void				append( const ci::Buffer& buffer );
+	void				append( const ci::BufferRef& buffer );
 	//! Returns message body.
-	const ci::Buffer&	getBody() const;
+	const ci::BufferRef&	getBody() const;
 	//! Sets or replaces message body with \a body.
-	void				setBody( const ci::Buffer& body );
+	void				setBody( const ci::BufferRef& body );
 
 	//! Converts entire message to ci::Buffer.
-	virtual ci::Buffer	toBuffer() const;
+	virtual ci::BufferRef	toBuffer() const;
 	//! Converts entire message to std::string.
 	virtual std::string	toString() const;
 protected:
 	BodyInterface();
 	
-	ci::Buffer			mBody;
+	ci::BufferRef		mBody;
 };
  

--- a/src/HeaderInterface.cpp
+++ b/src/HeaderInterface.cpp
@@ -72,18 +72,18 @@ string HeaderInterface::headerMapToString( const HeaderMap& h )
 	return headerMap;
 }
 
-Buffer HeaderInterface::removeHeader( const Buffer& buffer )
+BufferRef HeaderInterface::removeHeader( const BufferRef& buffer )
 {
 	string msg		= bufferToString( buffer );
 	size_t offset	= msg.find( sCrLf + sCrLf );
-	size_t sz		= buffer.getDataSize();
+	size_t sz		= buffer->getSize();
 	if ( offset < sz ) {
 		size_t len = ( sz - offset ) - 4;
-		Buffer body( len );
-		char_traits<char>::copy( (char*)body.getData(), (char*)buffer.getData() + ( offset + 4 ), len );
+        BufferRef body = Buffer::create( len );
+		char_traits<char>::copy( (char*)body->getData(), (char*)buffer->getData() + ( offset + 4 ), len );
 		return body;
 	} else {
-		return Buffer();
+		return Buffer::create( 0 );
 	}
 }
 
@@ -135,19 +135,19 @@ void HeaderInterface::setHeaders( const HeaderMap& headerMap )
 	mHeaderMap = headerMap;
 }
 
-void HeaderInterface::parse( const Buffer& buffer )
+void HeaderInterface::parse( const BufferRef& buffer )
 {
 	string msg		= bufferToString( buffer );
 	parseHeader( msg );
 }
 
-Buffer HeaderInterface::toBuffer() const
+BufferRef HeaderInterface::toBuffer() const
 {
 	string header	= headerToString();
 	size_t sz		= header.size();
 	
-	Buffer buffer( sz );
-	char_traits<char>::copy( (char*)buffer.getData(), (char*)&header[ 0 ], sz );
+    BufferRef buffer = Buffer::create( sz );
+	char_traits<char>::copy( (char*)buffer->getData(), (char*)&header[ 0 ], sz );
 	
 	return buffer;
 }

--- a/src/HeaderInterface.h
+++ b/src/HeaderInterface.h
@@ -49,7 +49,7 @@ public:
 	//! Return string representation of \a headerMap.
 	static std::string	headerMapToString( const HeaderMap& headerMap );
 	//! Returns copy of buffer with header removed.
-	static ci::Buffer	removeHeader( const ci::Buffer& buffer );
+	static ci::BufferRef	removeHeader( const ci::BufferRef& buffer );
 
 	//! Erases header named \a field.
 	void				eraseHeader( const std::string& field );
@@ -68,11 +68,11 @@ public:
 	// Sets all header fields from \a headerMap. Overwrites existing values.
 	void				setHeaders( const HeaderMap& headerMap );
 	//! Parses \a buffer into headers.
-	virtual void		parse( const ci::Buffer& buffer );
+	virtual void		parse( const ci::BufferRef& buffer );
 	virtual void		parseHeader( const std::string& header ) = 0;
 
 	//! Converts entire message to ci::Buffer.
-	virtual ci::Buffer	toBuffer() const;
+	virtual ci::BufferRef	toBuffer() const;
 	//! Converts entire message to std::string.
 	virtual std::string	toString() const;
 	

--- a/src/HttpInterface.cpp
+++ b/src/HttpInterface.cpp
@@ -99,36 +99,36 @@ void HttpInterface::setHttpVersion( HttpVersion v )
 	mHttpVersion = v;
 }
 
-void HttpInterface::parse( const Buffer& buffer )
+void HttpInterface::parse( const BufferRef& buffer )
 {
 	string msg		= bufferToString( buffer );
 	size_t offset	= msg.find( sCrLf + sCrLf );
-	size_t sz		= buffer.getDataSize();
+	size_t sz		= buffer->getSize();
 	if ( offset < sz ) {
 		msg = msg.substr( 0, offset );
 		parseHeader( msg );
 
 		size_t len = sz - offset;
-		Buffer body( len );
-		char_traits<char>::copy( (char*)body.getData(), (char*)buffer.getData() + ( offset + 4 ), len );
+        BufferRef body = Buffer::create( len );
+		char_traits<char>::copy( (char*)body->getData(), (char*)buffer->getData() + ( offset + 4 ), len );
 		mBody = body;
 	}
 }
 
-Buffer HttpInterface::toBuffer() const
+BufferRef HttpInterface::toBuffer() const
 {
 	string header		= headerToString();
 	size_t headerLength	= header.size();
 	size_t bodyLength	= 0;
 	if ( mBody ) {
-		bodyLength		= mBody.getDataSize();
+		bodyLength		= mBody->getSize();
 	}
 	size_t sz			= headerLength + bodyLength;
 
-	Buffer buffer( sz );
-	char_traits<char>::copy( (char*)buffer.getData(), (char*)&header[ 0 ], headerLength );
+    BufferRef buffer = Buffer::create( sz );
+	char_traits<char>::copy( (char*)buffer->getData(), (char*)&header[ 0 ], headerLength );
 	if ( bodyLength > 0 ) {
-		char_traits<char>::copy( (char*)buffer.getData() + headerLength, (char*)mBody.getData(), bodyLength );
+		char_traits<char>::copy( (char*)buffer->getData() + headerLength, (char*)mBody->getData(), bodyLength );
 	}
 
 	return buffer;

--- a/src/HttpInterface.h
+++ b/src/HttpInterface.h
@@ -59,10 +59,10 @@ public:
 	void					setHttpVersion( HttpVersion v );
 
 	//! Parses \a buffer to header and body. Throws exception for invalid header.
-	void					parse( const ci::Buffer& buffer );
+	void					parse( const ci::BufferRef& buffer );
 
 	//! Converts entire message to ci::Buffer.
-	ci::Buffer				toBuffer() const;
+	ci::BufferRef			toBuffer() const;
 	//! Converts entire message to std::string.
 	std::string				toString() const;
 

--- a/src/KeyValuePairInterface.cpp
+++ b/src/KeyValuePairInterface.cpp
@@ -59,7 +59,7 @@ void KeyValuePairInterface::setValue( const string& v )
 	mKeyValuePair.second = v;
 }
 
-void KeyValuePairInterface::parse( const Buffer& buffer )
+void KeyValuePairInterface::parse( const BufferRef& buffer )
 {
 	string s = bufferToString( buffer );
 	vector<string> lines;
@@ -76,7 +76,7 @@ void KeyValuePairInterface::parse( const Buffer& buffer )
 	}
 }
 
-Buffer KeyValuePairInterface::toBuffer() const
+BufferRef KeyValuePairInterface::toBuffer() const
 {
 	return stringToBuffer( toString() );
 }

--- a/src/KeyValuePairInterface.h
+++ b/src/KeyValuePairInterface.h
@@ -48,10 +48,10 @@ public:
 	void					setValue( const std::string& v );
 
 	//! Parses \a buffer to key-value pair.
-	void					parse( const ci::Buffer& buffer );
+	void					parse( const ci::BufferRef& buffer );
 
 	//! Converts message to ci::Buffer.
-	ci::Buffer				toBuffer() const;
+	ci::BufferRef			toBuffer() const;
 	//! Converts message to string.
 	virtual std::string		toString() const;
 protected:

--- a/src/ProtocolInterface.cpp
+++ b/src/ProtocolInterface.cpp
@@ -72,18 +72,18 @@ string ProtocolInterface::keyValuePairToString( const KeyValuePair& kvp, const s
 	return kvp.first + delim + kvp.second;
 }
 
-Buffer ProtocolInterface::stringToBuffer( const string& value )
+BufferRef ProtocolInterface::stringToBuffer( const string& value )
 {
-	Buffer buffer( value.size() );
-	buffer.copyFrom( (char*)&value[ 0 ], value.size() );
+    BufferRef buffer = Buffer::create( value.size() );
+	buffer->copyFrom( (char*)&value[ 0 ], value.size() );
 	return buffer;
 }
 
-string ProtocolInterface::bufferToString( const Buffer& buffer )
+string ProtocolInterface::bufferToString( const BufferRef& buffer )
 {
-	string s( static_cast<const char*>( buffer.getData() ) );
-	if ( s.length() > buffer.getDataSize() ) {
-		s.resize( buffer.getDataSize() );
+	string s( static_cast<const char*>( buffer->getData() ) );
+	if ( s.length() > buffer->getSize() ) {
+		s.resize( buffer->getSize() );
 	}
 	return s;
 }
@@ -91,7 +91,7 @@ string ProtocolInterface::bufferToString( const Buffer& buffer )
 void ProtocolInterface::parse( const string& msg )
 {
 	if ( !msg.empty() ) { 
-		Buffer buffer( (char*)&msg[ 0 ], msg.length() );
+        BufferRef buffer = Buffer::create( (char*)&msg[ 0 ], msg.length() );
 		parse( buffer );
 	}
 }

--- a/src/ProtocolInterface.h
+++ b/src/ProtocolInterface.h
@@ -54,16 +54,16 @@ public:
 	static std::string		keyValuePairToString( const KeyValuePair& kvp, const std::string& delim = " " );
 
 	//! Return string \a value as Buffer.
-	static ci::Buffer		stringToBuffer( const std::string& value );
+	static ci::BufferRef		stringToBuffer( const std::string& value );
 	//! Returns string representation of \a buffer.
-	static std::string		bufferToString( const ci::Buffer& buffer );
+	static std::string		bufferToString( const ci::BufferRef& buffer );
 	
-	virtual ci::Buffer		toBuffer() const = 0;
+	virtual ci::BufferRef	toBuffer() const = 0;
 	virtual std::string		toString() const = 0;
 
 	//! Parses \a msg into relevant commands, field, body, etc.
 	void					parse( const std::string& msg );
-	virtual void			parse( const ci::Buffer& buffer ) = 0;
+	virtual void			parse( const ci::BufferRef& buffer ) = 0;
 
 	//! Exception representing invalid key-value pair
 	class ExcKeyValuePairInvalid : public ci::Exception


### PR DESCRIPTION
Made necessary changes to the xcode project settings and configurations.
Made adjustments necessary due to changes in Cinder 0_9. Most are related to the ci::Buffer interface.
Building against pizthewiz/Cinder-Asio c2be183a5db19c6dffac69873e89b9f030e7c2d2 xcode-project-tweaks branch.
All samples compile and run with xcode 6.4.
Strange permission issue persists when launching HttpServer and WebClient sample.
